### PR TITLE
Skip non highlighted results from elastic search to avoid KeyError

### DIFF
--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -275,6 +275,8 @@ def _parse_es_ngram_search_results(ngram_results, ngrams_length):
     variant_dictionary = {}
     if ngram_results and ngram_results['hits']['total'] > 0:
         for hit in ngram_results['hits']['hits']:
+            if 'highlight' not in hit:
+                continue
             count_of_variants = len(hit['highlight']['variants'])
             count = 0
             while count < count_of_variants:


### PR DESCRIPTION
Some results returned from ES are extra because of fuzziness and end up not being highlighted, drop them instead of trying to access highlights avoiding KeyError altogether