### PR TITLE
Add a tokenizer that mimicks Lucene's Standard Tokenizer and fix tokenizer usages

### DIFF
--- a/chatbot_ner/config.py
+++ b/chatbot_ner/config.py
@@ -1,8 +1,9 @@
-import os
-import dotenv
 import logging.handlers
-from requests_aws4auth import AWS4Auth
+import os
+
+import dotenv
 from elasticsearch import RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 CONFIG_PATH = os.path.join(BASE_DIR, 'config')

--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -1,3 +1,4 @@
+from six import string_types
 import re
 
 from lib.nlp.const import TOKENIZER
@@ -143,7 +144,7 @@ def _get_dynamic_fuzziness_threshold(term, fuzzy_setting):
          int or str: fuzziness as int when ES version < 6.2
                      otherwise the input is returned as it is
     """
-    if type(fuzzy_setting) == str:
+    if isinstance(fuzzy_setting, string_types):
         if ELASTICSEARCH_VERSION_MAJOR > 6 or (ELASTICSEARCH_VERSION_MAJOR == 6 and ELASTICSEARCH_VERSION_MINOR >= 2):
             return fuzzy_setting
         return 'auto'

--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -1,7 +1,6 @@
 import re
 
-from ner_v1.language_utilities.constant import ENGLISH_LANG
-from chatbot_ner.config import ner_logger
+from lib.nlp.const import TOKENIZER
 from ..constants import ELASTICSEARCH_SEARCH_SIZE, ELASTICSEARCH_VERSION_MAJOR, ELASTICSEARCH_VERSION_MINOR
 
 log_prefix = 'datastore.elastic_search.query'
@@ -89,7 +88,7 @@ def full_text_query(connection, index_name, doc_type, entity_name, sentence, fuz
          u'pune': u'pune'}
     """
     data = _generate_es_search_dictionary(entity_name, sentence, fuzziness_threshold,
-                                                language_script=search_language_script)
+                                          language_script=search_language_script)
     kwargs = dict(kwargs, body=data, doc_type=doc_type, size=ELASTICSEARCH_SEARCH_SIZE, index=index_name)
     results = _run_es_search(connection, **kwargs)
     results = _parse_es_search_results(results)
@@ -221,13 +220,14 @@ def _generate_es_search_dictionary(entity_name, text, fuzziness_threshold, langu
 
 def _parse_es_search_results(results):
     """
-    Parses highlighted results returned from elasticsearch query on user typed sentence
+    Parse highlighted results returned from elasticsearch query and generate a variants to values dictionary
 
     Args:
         results: search results dictionary from elasticsearch including highlights and scores
 
     Returns:
-        dictionary of the parsed results from highlighted search query results on ngrams_list
+        dict: dict mapping matching variants to their entity values based on the
+              parsed results from highlighted search query results
 
     Example:
         Parameter ngram_results has highlighted search results as follows:
@@ -268,31 +268,32 @@ def _parse_es_search_results(results):
         }
 
     """
-    entity_value_list, variant_value_list = [], []
-    variant_dictionary = {}
+    entity_values, entity_variants = [], []
+    variants_to_values = {}
     if results and results['hits']['total'] > 0:
         for hit in results['hits']['hits']:
             if 'highlight' not in hit:
                 continue
-            count_of_variants = len(hit['highlight']['variants'])
-            count = 0
-            while count < count_of_variants:
-                entity_value_list.append(hit['_source']['value'])
-                variant_value_list.append(hit['highlight']['variants'][count])
-                count += 1
-    count = 0
 
-    while count < len(variant_value_list):
-        variant_value_list[count] = re.sub('\s+', ' ', variant_value_list[count]).strip()
-        if variant_value_list[count].count('<em>') == len(variant_value_list[count].split()):
-            variant = variant_value_list[count].replace('<em>', '')
+            value = hit['_source']['value']
+            for variant in hit['highlight']['variants']:
+                entity_values.append(value)
+                entity_variants.append(variant)
+
+    for value, variant in zip(entity_values, entity_variants):
+        variant = re.sub('\s+', ' ', variant.strip())
+        variant_tokens = TOKENIZER.tokenize(variant)
+        if variant.count('<em>') == len(variant_tokens):
+            variant = variant.replace('<em>', '')
             variant = variant.replace('</em>', '')
-            if variant.strip() in variant_dictionary:
-                existing_value = variant_dictionary[variant.strip()]
-                if len(existing_value.split(' ')) > len(entity_value_list[count].split(' ')):
-                    variant_dictionary[variant.strip()] = entity_value_list[count]
+            variant = variant.strip()
+            if variant in variants_to_values:
+                old_value = variants_to_values[variant]
+                if len(TOKENIZER.tokenize(old_value)) > len(TOKENIZER.tokenize(value)):
+                    # Note: Although this condition evaluates to true rarely, it is unclear why we settle
+                    # on values with lesser number of tokens. This is subject to change in the future.
+                    variants_to_values[variant] = value
             else:
-                variant_dictionary[variant.strip()] = entity_value_list[count]
-        count += 1
+                variants_to_values[variant] = value
 
-    return variant_dictionary
+    return variants_to_values

--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -285,13 +285,7 @@ def _parse_es_search_results(results):
         variant_no_highlight_tags = variant.replace('<em>', '').replace('</em>', '').strip()
         if variant.count('<em>') == len(TOKENIZER.tokenize(variant_no_highlight_tags)):
             variant = variant_no_highlight_tags
-            if variant in variants_to_values:
-                old_value = variants_to_values[variant]
-                if len(TOKENIZER.tokenize(old_value)) > len(TOKENIZER.tokenize(value)):
-                    # Note: Although this condition evaluates to true rarely, it is unclear why we settle
-                    # on values with lesser number of tokens. This is subject to change in the future.
-                    variants_to_values[variant] = value
-            else:
+            if variant not in variants_to_values:
                 variants_to_values[variant] = value
 
     return variants_to_values

--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -282,11 +282,9 @@ def _parse_es_search_results(results):
 
     for value, variant in zip(entity_values, entity_variants):
         variant = re.sub('\s+', ' ', variant.strip())
-        variant_tokens = TOKENIZER.tokenize(variant)
-        if variant.count('<em>') == len(variant_tokens):
-            variant = variant.replace('<em>', '')
-            variant = variant.replace('</em>', '')
-            variant = variant.strip()
+        variant_no_highlight_tags = variant.replace('<em>', '').replace('</em>', '').strip()
+        if variant.count('<em>') == len(TOKENIZER.tokenize(variant_no_highlight_tags)):
+            variant = variant_no_highlight_tags
             if variant in variants_to_values:
                 old_value = variants_to_values[variant]
                 if len(TOKENIZER.tokenize(old_value)) > len(TOKENIZER.tokenize(value)):

--- a/lib/nlp/const.py
+++ b/lib/nlp/const.py
@@ -3,15 +3,19 @@ from lib.nlp.etc import store_data_in_list
 from lib.nlp.lemmatizer import Lemmatizer, WORDNET_LEMMATIZER
 from lib.nlp.ngram import Ngram
 from lib.nlp.stemmer import Stemmer, PORTER_STEMMER
-from lib.nlp.tokenizer import Tokenizer, PRELOADED_NLTK_TOKENIZER
+from lib.nlp.tokenizer import Tokenizer, PRELOADED_NLTK_TOKENIZER, LUCENE_STANDARD_TOKENIZER
 from lib.nlp.regex import Regex
 from chatbot_ner.settings import BASE_DIR
 
 
 stemmer = Stemmer(PORTER_STEMMER)
 lemmatizer = Lemmatizer(WORDNET_LEMMATIZER)
-tokenizer = Tokenizer(PRELOADED_NLTK_TOKENIZER)
+nltk_tokenizer = Tokenizer(PRELOADED_NLTK_TOKENIZER)
+lucene_tokenizer = Tokenizer(LUCENE_STANDARD_TOKENIZER)
 
+# Currently we support only elasticsearch as datastore engine, so it safe to use lucene tokenizer as default
+# This could change in future
+TOKENIZER = lucene_tokenizer
 
 # Creating list of stop words
 stop_word_path = os.path.join(BASE_DIR, 'lib', 'nlp', 'data', 'stop_words.csv')  # file containing words to remove

--- a/lib/nlp/const.py
+++ b/lib/nlp/const.py
@@ -4,7 +4,7 @@ from lib.nlp.lemmatizer import Lemmatizer, WORDNET_LEMMATIZER
 from lib.nlp.ngram import Ngram
 from lib.nlp.stemmer import Stemmer, PORTER_STEMMER
 from lib.nlp.tokenizer import Tokenizer, PRELOADED_NLTK_TOKENIZER, LUCENE_STANDARD_TOKENIZER
-from lib.nlp.regex import Regex
+from lib.nlp.regexreplace import RegexReplace
 from chatbot_ner.settings import BASE_DIR
 
 
@@ -24,5 +24,5 @@ stop_words = store_data_in_list(stop_word_path)
 ngram_object = Ngram()
 
 punctuation_removal_list = [(r'[^\w\'\/]', r' '), (r'\'', r'')]
-regx_punctuation_removal = Regex(punctuation_removal_list)
+regx_punctuation_removal = RegexReplace(punctuation_removal_list)
 

--- a/lib/nlp/data_normalization.py
+++ b/lib/nlp/data_normalization.py
@@ -14,7 +14,7 @@ class Normalization(object):
         ngram: its an object of Ngram class
         tokenizer: its an object of Tokenizer class
         stemmer: its an object of Stemmer class
-        regx_to_process: its an object of Regex class
+        regx_to_process: its an object of RegexReplace class
         stop_word_list: list of stop words
         text: message that needs to be processed
         text_to_process: isa text but regular expression and all the processing operations are performed on this

--- a/lib/nlp/data_normalization.py
+++ b/lib/nlp/data_normalization.py
@@ -1,4 +1,4 @@
-from lib.nlp.const import lemmatizer, ngram_object, tokenizer, stemmer, regx_punctuation_removal, \
+from lib.nlp.const import lemmatizer, ngram_object, nltk_tokenizer, stemmer, regx_punctuation_removal, \
     stop_words
 from lib.nlp.etc import filter_list
 from chatbot_ner.config import nlp_logger
@@ -95,7 +95,8 @@ class Normalization(object):
 
         self.lemmatizer = lemmatizer
         self.ngram = ngram_object
-        self.tokenizer = tokenizer
+        # CAUTION: The following nltk_tokenizer (nltk punkt) is different from elasticsearch's standard tokenizer
+        self.tokenizer = nltk_tokenizer
         self.stemmer = stemmer
         self.regx_to_process = regx_punctuation_removal
 

--- a/lib/nlp/levenshtein_distance.py
+++ b/lib/nlp/levenshtein_distance.py
@@ -22,10 +22,12 @@ def edit_distance(string1, string2, insertion_cost=1, deletion_cost=1, substitut
     So, whenever distance exceeds the max_distance the function will break and return the max_distance else
     it will return levenshtein distance
     """
-    if type(string1) == str:
+    if isinstance(string1, bytes):
         string1 = string1.decode('utf-8')
-    if type(string2) == str:
+
+    if isinstance(string2, bytes):
         string2 = string2.decode('utf-8')
+
     if len(string1) > len(string2):
         string1, string2 = string2, string1
     distances = range(len(string1) + 1)

--- a/lib/nlp/regexreplace.py
+++ b/lib/nlp/regexreplace.py
@@ -17,8 +17,6 @@ class RegexReplace(object):
 
     Attributes:
         pattern_list: List of tuples -> [(pattern_to_search, pattern_to_replace),...]
-        text: text on which regex needs to be performed
-        processed_text: Its text that will store the output
         pattern_compile: Object of 're' gets created for each pattern present in the list
 
     """
@@ -31,9 +29,7 @@ class RegexReplace(object):
         """
 
         self.pattern_list = pattern_list
-        self.text = None
-        self.processed_text = None
-        self.pattern_compile = [re.compile(pattern[0]) for pattern in self.pattern_list]
+        self.pattern_compile = [re.compile(pattern[0], re.IGNORECASE | re.UNICODE) for pattern in self.pattern_list]
 
     def text_substitute(self, text):
         """
@@ -43,7 +39,7 @@ class RegexReplace(object):
             text: text on which substitution needs to be performed
 
         Returns:
-            will return the substituted text
+            str: text
             For example:
                 pattern_list = [('[\,\?]', ''),(r'\bu\b','you')]
                 regex = RegexReplace(pattern_list)
@@ -52,8 +48,7 @@ class RegexReplace(object):
                 >> 'Hey where are you going'
 
         """
-        self.text = text
-        self.processed_text = self.text
+        processed_text = text
         for i, compiled_pattern in enumerate(self.pattern_compile):
-            self.processed_text = compiled_pattern.sub(self.pattern_list[i][1], self.text)
-        return self.processed_text
+            processed_text = compiled_pattern.sub(self.pattern_list[i][1], processed_text)
+        return processed_text

--- a/lib/nlp/regexreplace.py
+++ b/lib/nlp/regexreplace.py
@@ -1,7 +1,7 @@
 import re
 
 
-class Regex(object):
+class RegexReplace(object):
     """
     This class is used to perform regex operations
     Its a class which can be used to perform various regex operations like substitution, pattern matching, searching,
@@ -10,7 +10,7 @@ class Regex(object):
 
     For Example:
         pattern_list = [('[\,\?]', ''),(r'\bu\b','you')]
-        regex = Regex(pattern_list)
+        regex = RegexReplace(pattern_list)
         output = regex.text_substitute('Hey, where are u going?')
         print output
         >> 'Hey where are you going'
@@ -24,7 +24,7 @@ class Regex(object):
     """
 
     def __init__(self, pattern_list):
-        """Initializes a Regex object
+        """Initializes a RegexReplace object
 
         Args:
             pattern_list: List of tuples -> [(pattern_to_search, pattern_to_replace),...]
@@ -46,7 +46,7 @@ class Regex(object):
             will return the substituted text
             For example:
                 pattern_list = [('[\,\?]', ''),(r'\bu\b','you')]
-                regex = Regex(pattern_list)
+                regex = RegexReplace(pattern_list)
                 output = regex.text_substitute('Hey, where are u going?')
                 print output
                 >> 'Hey where are you going'

--- a/lib/nlp/tokenizer.py
+++ b/lib/nlp/tokenizer.py
@@ -83,7 +83,7 @@ class Tokenizer(object):
         return word_tokenize
 
     def get_tokenizer(self):
-        """Returns the object of tokenizer
+        """Get the object of set tokenizer
 
         Returns:
             The object of tokenizer

--- a/lib/nlp/tokenizer.py
+++ b/lib/nlp/tokenizer.py
@@ -1,10 +1,12 @@
 import nltk
 
+import regex
 # constants
 from lib.singleton import Singleton
 
 NLTK_TOKENIZER = 'WORD_TOKENIZER'
 PRELOADED_NLTK_TOKENIZER = 'PRELOADED_NLTK_TOKENIZER'
+LUCENE_STANDARD_TOKENIZER = 'LUCENE_STANDARD_TOKENIZER'
 
 
 class Tokenizer(object):
@@ -38,8 +40,21 @@ class Tokenizer(object):
         self.tokenizer_dict = {
             NLTK_TOKENIZER: self.__nltk_tokenizer,
             PRELOADED_NLTK_TOKENIZER: self.__preloaded_nltk_tokenizer,
+            LUCENE_STANDARD_TOKENIZER: self.__lucene_standard_tokenizer,
         }
         self.tokenizer = self.tokenizer_dict[self.tokenizer_selected]()
+
+    def __lucene_standard_tokenizer(self):
+        """
+        Tokenizer that mimicks Elasticsearch/Lucene's standard tokenizer
+        Uses word boundaries defined in Unicode Annex 29
+        """
+        words_pattern = regex.compile(r'\w(?:\B\S)*', flags=regex.V1 | regex.WORD | regex.UNICODE)
+
+        def word_tokenize(text):
+            return words_pattern.findall(text)
+
+        return word_tokenize
 
     def __nltk_tokenizer(self):
         """Initializes Word Tokenizer
@@ -50,6 +65,10 @@ class Tokenizer(object):
         return nltk.word_tokenize
 
     def __preloaded_nltk_tokenizer(self):
+        """
+        Faster version of nltk punkt tokenizer. It avoids a heavy I/O cycle at each tokenize call by preloading it
+        WARNING! It loads only the english tokenizer
+        """
         # Code pulled out of nltk == 3.2.5
         tokenizer = nltk.load('tokenizers/punkt/{0}.pickle'.format('english'))
         sent_tokenizer = tokenizer.tokenize

--- a/lib/singleton.py
+++ b/lib/singleton.py
@@ -4,6 +4,12 @@ class Singleton(type):
     A pythonic Singleton implementation to be implemented with metaclass. Based on the pros and cons from
     https://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
 
+
+    This is a Singleton metaclass. All classes affected by this metaclass
+    have the property that only one instance is created for each set of arguments
+    passed to the class constructor.
+
+
     Sample Implementation:
 
     #Python2
@@ -15,9 +21,16 @@ class Singleton(type):
         pass
 
     """
-    _instances = {}
+
+    def __init__(cls, name, bases, dict):
+        super(Singleton, cls).__init__(cls, bases, dict)
+        cls._instanceDict = {}
 
     def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
+        argdict = {'args': args}
+        argdict.update(kwargs)
+        argset = frozenset(sorted(argdict.items()))
+        if argset not in cls._instanceDict:
+            cls._instanceDict[argset] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instanceDict[argset]
+

--- a/models/crf/test.py
+++ b/models/crf/test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from lib.nlp.const import tokenizer
+from lib.nlp.const import nltk_tokenizer
 from lib.nlp.pos import POS
 from models.constant import CITY_ENTITY_TYPE, DATE_ENTITY_TYPE, CITY_MODEL_OBJECT, DATE_MODEL_OBJECT
 from models.constant import INBOUND, OUTBOUND
@@ -156,8 +156,8 @@ class PredictCRF(object):
         if bot_message is None:
             bot_message = ''
 
-        tokens_bot_message = tokenizer.tokenize(bot_message)
-        tokens_user_message = tokenizer.tokenize(user_message)
+        tokens_bot_message = nltk_tokenizer.tokenize(bot_message)
+        tokens_user_message = nltk_tokenizer.tokenize(user_message)
 
         pos_bot_message = self.pos_tagger.tag(tokens_bot_message)
         pos_user_message = self.pos_tagger.tag(tokens_user_message)

--- a/ner_v1/api.py
+++ b/ner_v1/api.py
@@ -377,6 +377,7 @@ def combine_output(request):
     ner_logger.debug('Finished %s : %s ' % (message, output))
     return HttpResponse(json.dumps({'data': output}), content_type='application/json')
 
+
 def parse_fuzziness_parameter(fuzziness):
     """
     This function takes input as the fuzziness value.

--- a/ner_v1/chatbot/combine_detection_logic.py
+++ b/ner_v1/chatbot/combine_detection_logic.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from future.utils import iteritems
+from six import iteritems
 
 from lib.nlp.const import TOKENIZER
 from lib.nlp.regexreplace import RegexReplace

--- a/ner_v1/chatbot/combine_detection_logic.py
+++ b/ner_v1/chatbot/combine_detection_logic.py
@@ -74,7 +74,7 @@ def combine_output_of_detection_logic_and_tag(entity_data, text):
           }
 
     """
-    regex = RegexReplace([(r'[\'\/]', r'')])
+    regex = RegexReplace([(r'[\'\/]', r''), (r'\s+', r' ')])
     text = regex.text_substitute(text)
     final_entity_data = defaultdict(list)
     tagged_text = text.lower()

--- a/ner_v1/chatbot/combine_detection_logic.py
+++ b/ner_v1/chatbot/combine_detection_logic.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from future.utils import iteritems
 
 from lib.nlp.const import TOKENIZER
-from lib.nlp.regex import Regex
+from lib.nlp.regexreplace import RegexReplace
 from ner_v1.constant import ORIGINAL_TEXT, DETECTION_METHOD, FROM_MESSAGE, FROM_MODEL_VERIFIED, FROM_MODEL_NOT_VERIFIED
 
 
@@ -74,7 +74,7 @@ def combine_output_of_detection_logic_and_tag(entity_data, text):
           }
 
     """
-    regex = Regex([(r'[\'\/]', r'')])
+    regex = RegexReplace([(r'[\'\/]', r'')])
     text = regex.text_substitute(text)
     final_entity_data = defaultdict(list)
     tagged_text = text.lower()

--- a/ner_v1/chatbot/combine_detection_logic.py
+++ b/ner_v1/chatbot/combine_detection_logic.py
@@ -1,5 +1,8 @@
 from collections import defaultdict
-from lib.nlp.const import tokenizer
+
+from future.utils import iteritems
+
+from lib.nlp.const import TOKENIZER
 from lib.nlp.regex import Regex
 from ner_v1.constant import ORIGINAL_TEXT, DETECTION_METHOD, FROM_MESSAGE, FROM_MODEL_VERIFIED, FROM_MODEL_NOT_VERIFIED
 
@@ -77,12 +80,12 @@ def combine_output_of_detection_logic_and_tag(entity_data, text):
     tagged_text = text.lower()
     processed_text = text.lower()
     tag_preprocess_dict = defaultdict(list)
-    for entity, entity_list in entity_data.iteritems():
+    for entity, entity_list in iteritems(entity_data):
         if entity_list:
             for entity_identified in entity_list:
                 if entity_identified[ORIGINAL_TEXT] and \
-                                entity_identified[DETECTION_METHOD] in [FROM_MESSAGE, FROM_MODEL_VERIFIED,
-                                                                        FROM_MODEL_NOT_VERIFIED]:
+                        entity_identified[DETECTION_METHOD] in [FROM_MESSAGE, FROM_MODEL_VERIFIED,
+                                                                FROM_MODEL_NOT_VERIFIED]:
                     tag_preprocess_dict[entity_identified[ORIGINAL_TEXT].lower()].append([entity_identified, entity])
                 else:
                     tag_preprocess_dict['NA'].append([entity_identified, entity])
@@ -127,9 +130,9 @@ def sort_original_text(original_text_list):
     """
     final_original_text = []
     sort_original_text_dict = defaultdict(list)
-    original_text_list.sort(key=lambda s: len(tokenizer.tokenize(s)), reverse=True)
+    original_text_list.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
     for original in original_text_list:
-        length_of_token = len(tokenizer.tokenize(original))
+        length_of_token = len(TOKENIZER.tokenize(original))
         sort_original_text_dict[length_of_token].append(original)
     for token_length in reversed(sorted(sort_original_text_dict.keys())):
         list_of_tokens = sort_original_text_dict[token_length]

--- a/ner_v1/detectors/numeral/budget/budget_detection.py
+++ b/ner_v1/detectors/numeral/budget/budget_detection.py
@@ -1,7 +1,7 @@
 import re
 
 from ner_v1.detectors.constant import BUDGET_TYPE_NORMAL, BUDGET_TYPE_TEXT, ES_BUDGET_LIST
-from lib.nlp.regex import Regex
+from lib.nlp.regexreplace import RegexReplace
 from ner_v1.detectors.textual.text.text_detection import TextDetector
 
 
@@ -97,7 +97,7 @@ class BudgetDetector(object):
         self.original_budget_text = []
 
         regex_for_thousand = [(r'(\d+)k', r'\g<1>000')]
-        self.regex_object = Regex(regex_for_thousand)
+        self.regex_object = RegexReplace(regex_for_thousand)
         self.tag = '__' + self.entity_name + '__'
         self.text_detection_object = TextDetector(entity_name=ES_BUDGET_LIST)
 

--- a/ner_v1/detectors/textual/city/city_detection.py
+++ b/ner_v1/detectors/textual/city/city_detection.py
@@ -19,7 +19,7 @@ class CityDetector(object):
         text: string to extract entities from
         entity_name: string by which the detected city entities would be replaced with on calling detect_entity()
         tagged_text: string with city entities replaced with tag defined by entity_name
-        text_entity: list to store detected entities from the text
+        city: list to store detected entities from the text
         processed_text: string with detected time entities removed
         tag: entity_name prepended and appended with '__'
     """

--- a/ner_v1/detectors/textual/name/name_detection.py
+++ b/ner_v1/detectors/textual/name/name_detection.py
@@ -1,8 +1,9 @@
-from lib.nlp.tokenizer import Tokenizer
-from ner_v1.detectors.textual.text.text_detection import TextDetector
-from ner_v1.constant import FIRST_NAME, MIDDLE_NAME, LAST_NAME
-from lib.nlp.pos import *
 import re
+
+from lib.nlp.const import tokenizer
+from lib.nlp.pos import *
+from ner_v1.constant import FIRST_NAME, MIDDLE_NAME, LAST_NAME
+from ner_v1.detectors.textual.text.text_detection import TextDetector
 
 
 class NameDetector(object):
@@ -167,7 +168,7 @@ class NameDetector(object):
 
         """
 
-        replaced_text = Tokenizer().tokenize(self.text.lower())
+        replaced_text = tokenizer.tokenize(self.text.lower())
         for detected_original_text in (text_detection_result[1]):
             for j in range(len(replaced_text)):
                 replaced_text[j] = replaced_text[j].replace(detected_original_text, "_" + detected_original_text + "_")

--- a/ner_v1/detectors/textual/name/name_detection.py
+++ b/ner_v1/detectors/textual/name/name_detection.py
@@ -1,6 +1,6 @@
 import re
 
-from lib.nlp.const import tokenizer
+from lib.nlp.const import nltk_tokenizer
 from lib.nlp.pos import *
 from ner_v1.constant import FIRST_NAME, MIDDLE_NAME, LAST_NAME
 from ner_v1.detectors.textual.text.text_detection import TextDetector
@@ -168,7 +168,7 @@ class NameDetector(object):
 
         """
 
-        replaced_text = tokenizer.tokenize(self.text.lower())
+        replaced_text = nltk_tokenizer.tokenize(self.text.lower())
         for detected_original_text in (text_detection_result[1]):
             for j in range(len(replaced_text)):
                 replaced_text[j] = replaced_text[j].replace(detected_original_text, "_" + detected_original_text + "_")

--- a/ner_v1/detectors/textual/text/text_detection.py
+++ b/ner_v1/detectors/textual/text/text_detection.py
@@ -1,7 +1,6 @@
 import re
 
-from future.utils import iteritems
-
+from six import iteritems
 from datastore import DataStore
 from lib.nlp.const import TOKENIZER
 from lib.nlp.levenshtein_distance import edit_distance

--- a/ner_v1/detectors/textual/text/text_detection.py
+++ b/ner_v1/detectors/textual/text/text_detection.py
@@ -54,7 +54,7 @@ class TextDetector(BaseDetector):
         super(TextDetector, self).__init__(source_language_script, translation_enabled)
 
         self.text = None
-        self.regx_to_process = RegexReplace([(r'[\'\/]', r'')])
+        self.regx_to_process = RegexReplace([(r'[\'\/]', r''), (r'\s+', r' ')])
         self.text_dict = {}
         self.tagged_text = None
         self.text_entity_values = []
@@ -193,7 +193,7 @@ class TextDetector(BaseDetector):
         """
         self.text = text.lower()
         self.processed_text = self.regx_to_process.text_substitute(self.text)
-        self.processed_text = u' ' + u' '.join(TOKENIZER.tokenize(self.processed_text)) + u' '
+        self.processed_text = u' ' + self.processed_text + u' '
         self.tagged_text = self.processed_text
 
         values, original_texts = self._text_detection_with_variants()

--- a/ner_v1/detectors/textual/text/text_detection.py
+++ b/ner_v1/detectors/textual/text/text_detection.py
@@ -3,7 +3,7 @@ import re
 from datastore import DataStore
 from lib.nlp.const import TOKENIZER
 from lib.nlp.levenshtein_distance import edit_distance
-from lib.nlp.regex import Regex
+from lib.nlp.regexreplace import RegexReplace
 from ner_v1.detectors.base_detector import BaseDetector
 from ner_v1.language_utilities.constant import ENGLISH_LANG, HINDI_LANG
 
@@ -20,7 +20,7 @@ class TextDetector(BaseDetector):
     Attributes:
         text (str): string to extract entities from
         entity_name (str): string by which the detected time entities would be replaced with on calling detect_entity()
-        regx_to_process (lib.nlp.Regex): list of regex patterns to match and remove text that matches
+        regx_to_process (lib.nlp.RegexReplace): list of regex patterns to match and remove text that matches
                                          these patterns before starting to detect entities
         text_dict (dict): dictionary to store lemmas, stems, ngrams used during detection process
         _fuzziness (str or int): If this parameter is str, elasticsearch's
@@ -54,7 +54,7 @@ class TextDetector(BaseDetector):
         super(TextDetector, self).__init__(source_language_script, translation_enabled)
 
         self.text = None
-        self.regx_to_process = Regex([(r'[\'\/]', r'')])
+        self.regx_to_process = RegexReplace([(r'[\'\/]', r'')])
         self.text_dict = {}
         self.tagged_text = None
         self.text_entity_values = []
@@ -285,7 +285,6 @@ class TextDetector(BaseDetector):
         variant_token_i = 0
         for text_token in text_tokens:
             variant_token = variant_tokens[variant_token_i]
-
 
             same = variant_token == text_token
             ft = self._get_fuzziness_threshold_for_token(text_token)

--- a/ner_v1/detectors/textual/text/text_detection.py
+++ b/ner_v1/detectors/textual/text/text_detection.py
@@ -286,13 +286,10 @@ class TextDetector(BaseDetector):
         for text_token in text_tokens:
             variant_token = variant_tokens[variant_token_i]
 
-            utext_token = text_token
-            if type(utext_token) == 'str':
-                utext_token = utext_token.decode('utf-8')
 
             same = variant_token == text_token
-            ft = self._get_fuzziness_threshold_for_token(utext_token)
-            if same or (len(utext_token) > self._min_token_size_for_fuzziness
+            ft = self._get_fuzziness_threshold_for_token(text_token)
+            if same or (len(text_token) > self._min_token_size_for_fuzziness
                         and edit_distance(string1=variant_token,
                                           string2=text_token,
                                           max_distance=ft + 1) <= ft):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,6 @@ requests-aws4auth==0.9
 django==1.8
 django-dotenv==1.3.0
 weighted-levenshtein==0.1
+regex
 ipython
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six==1.11.0
 gunicorn==19.6.0
 pytz==2014.2
 nltk==3.2.5
@@ -8,6 +9,6 @@ requests-aws4auth==0.9
 django==1.8
 django-dotenv==1.3.0
 weighted-levenshtein==0.1
-regex
+regex==2018.7.11
 ipython
 


### PR DESCRIPTION
Elasticsearch's Standard tokenizer follows unicode word boundaries and splits on certain symbols.
The already present nltk tokenizer does not generate the same tokens. Moreover at some places we use nltk tokenizer while at others we use arbitrary symbols to split on using `str.split` or `unicode.split`

As a result of some conditionals that ensure highlighted results have same number of terms as requested we end up dropping some matched results from elasticsearch

This PR adds a tokenizer that mimicks Lucene's Standard Tokenizer.