### PR TITLE
Sort highlights of search results by relevance

### DIFF
--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -226,6 +226,7 @@ def _generate_es_ngram_search_dictionary(entity_name, ngrams_list, fuzziness_thr
         'fields': {
             'variants': {}
         },
+        'order': 'score',
         'number_of_fragments': 20
     }
 


### PR DESCRIPTION
This will help bring relevant matches at the top and avoid them being omitted since we only request at most 20 fragments