### PR TITLE
TextDetection - Use ordering for variants returned by elasticsearch

### DIFF
--- a/datastore/datastore.py
+++ b/datastore/datastore.py
@@ -231,7 +231,7 @@ class DataStore(object):
                     Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.search
 
         Returns:
-            dictionary mapping entity value variants to their entity value
+            collections.OrderedDict: dictionary mapping entity value variants to their entity value
 
         Example:
             db = DataStore()

--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -1,6 +1,6 @@
 from six import string_types
 import re
-
+import collections
 from lib.nlp.const import TOKENIZER
 from ..constants import ELASTICSEARCH_SEARCH_SIZE, ELASTICSEARCH_VERSION_MAJOR, ELASTICSEARCH_VERSION_MINOR
 
@@ -63,8 +63,9 @@ def full_text_query(connection, index_name, doc_type, entity_name, sentence, fuz
             Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.Elasticsearch.search
 
     Returns:
-        dictionary of the parsed results from highlighted search query results on the sentence,
-        mapping highlighted fuzzy entity variant to entity value
+        collections.OrderedDict: dictionary of the parsed results from highlighted search query results
+                                 on the sentence, mapping highlighted fuzzy entity variant to entity value ordered
+                                 by relevance order returned by elasticsearch
 
     Example:
         # The following example is just for demonstration purpose. Normally we should call
@@ -223,11 +224,11 @@ def _parse_es_search_results(results):
     Parse highlighted results returned from elasticsearch query and generate a variants to values dictionary
 
     Args:
-        results: search results dictionary from elasticsearch including highlights and scores
+        results (dict): search results dictionary from elasticsearch including highlights and scores
 
     Returns:
-        dict: dict mapping matching variants to their entity values based on the
-              parsed results from highlighted search query results
+        collections.OrderedDict: dict mapping matching variants to their entity values based on the
+                                 parsed results from highlighted search query results
 
     Example:
         Parameter ngram_results has highlighted search results as follows:
@@ -269,7 +270,7 @@ def _parse_es_search_results(results):
 
     """
     entity_values, entity_variants = [], []
-    variants_to_values = {}
+    variants_to_values = collections.OrderedDict()
     if results and results['hits']['total'] > 0:
         for hit in results['hits']['hits']:
             if 'highlight' not in hit:

--- a/ner_v1/detectors/textual/text/text_detection.py
+++ b/ner_v1/detectors/textual/text/text_detection.py
@@ -1,5 +1,5 @@
 import re
-
+import collections
 from six import iteritems
 
 from chatbot_ner.config import ner_logger
@@ -313,7 +313,7 @@ class TextDetector(BaseDetector):
         """
         original_final_list = []
         value_final_list = []
-        variants_to_values = {}
+        variants_to_values = collections.OrderedDict()
 
         _variants_to_values = self.db.get_similar_dictionary(entity_name=self.entity_name,
                                                              text=u' '.join(TOKENIZER.tokenize(self.processed_text)),
@@ -326,20 +326,24 @@ class TextDetector(BaseDetector):
 
             variants_to_values[variant] = value
 
-        variants = variants_to_values.keys()
+        variants_list = variants_to_values.keys()
 
-        exact_matches, fuzzy_variants = [], []
-        for variant in variants:
-            if variant in self.processed_text:
-                exact_matches.append(variant)
-            else:
-                fuzzy_variants.append(variant)
+        # Length based ordering, this reorders the results from datastore
+        # that are already sorted by some relevance scoring
 
-        exact_matches.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
-        fuzzy_variants.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
-        variant_list = exact_matches + fuzzy_variants
+        # exact_matches, fuzzy_variants = [], []
+        # _text = u' '.join(TOKENIZER.tokenize(self.processed_text))
+        # for variant in variants_list:
+        #     if u' '.join(TOKENIZER.tokenize(variant)) in _text:
+        #         exact_matches.append(variant)
+        #     else:
+        #         fuzzy_variants.append(variant)
+        #
+        # exact_matches.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
+        # fuzzy_variants.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
+        # variants_list = exact_matches + fuzzy_variants
 
-        for variant in variant_list:
+        for variant in variants_list:
             original_text = self._get_entity_substring_from_text(variant, self.processed_text)
             if original_text:
                 value_final_list.append(variants_to_values[variant])


### PR DESCRIPTION
Trying to reorder variants is brittle and depends on strict exact matching that is very easy to break, this causes a problem when there are nested entity variants or when some entity variants are substrings of others and longer one fails to match exactly in processed text. Moving forward we can keep it simple and rely on relevance order returned by elasticsearch