### PR TITLE
Revert ordering change and check exacts with tokenized text

### DIFF
--- a/datastore/datastore.py
+++ b/datastore/datastore.py
@@ -60,7 +60,7 @@ class DataStore(object):
             All other exceptions raised by elasticsearch-py library
         """
         if self._engine == ELASTICSEARCH:
-            self._store_name = self._connection_settings.get(ELASTICSEARCH_INDEX_NAME, '_all')
+            self._store_name = self._connection_settings[ELASTICSEARCH_INDEX_NAME]
             self._client_or_connection = elastic_search.connect.connect(**self._connection_settings)
         else:
             self._client_or_connection = None

--- a/datastore/elastic_search/create.py
+++ b/datastore/elastic_search/create.py
@@ -85,7 +85,8 @@ def create_index(connection, index_name, doc_type, logger, **kwargs):
                 'properties': {
                     'variants': {
                         'type': 'string',
-                        'analyzer': 'my_analyzer'
+                        'analyzer': 'my_analyzer',
+                        'norms': {'enabled': False},  # Needed if we want to give longer variants higher scores
                     }
                 }
             }

--- a/datastore/exceptions.py
+++ b/datastore/exceptions.py
@@ -1,5 +1,5 @@
 __all__ = [
-    'DataStoreSettingsImproperlyConfiguredException', 'EngineNotImplementedException',
+    'DataStoreSettingsImproperlyConfiguredException', 'EngineNotImplementedException', 'EngineConnectionException'
 ]
 
 

--- a/docs/adding_entities.md
+++ b/docs/adding_entities.md
@@ -65,7 +65,7 @@ Now lets add the newly created csv file to the datastore.
 - Make sure to start the engine you configured with datastore( eg. elasticsearch)
 
   ```shell
-  $ ~/chatbot_ner_elasticsearch/elasticsearch-2.4.4/bin/elasticsearch -d
+  $ ~/chatbot_ner_elasticsearch/elasticsearch-5.5.0/bin/elasticsearch -d
   ```
 
 - Activate chatbot_ner virtual environment

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,4 +1,7 @@
 # Setup of Chatbot NER via. Docker
+> Note: The docker setup creates no user and uses elasticsearch 2.x in root mode,
+> the support for which has been removed since elasticsearch 5.x.
+> The code in develop has been changed to support 5.x+ but the docker file has not been updated yet
 
 Following are the steps to create the Docker image and run NER via Docker.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -65,12 +65,12 @@
     ```shell
     $ mkdir -p ~/chatbot_ner_elasticsearch
     $ cd /tmp/
-    $ curl -L -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz
-    $ tar -xzf elasticsearch-6.0.0.tar.gz -C ~/chatbot_ner_elasticsearch/
-    $ ~/chatbot_ner_elasticsearch/elasticsearch-6.0.0/bin/elasticsearch -d
+    $ curl -L -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.tar.gz
+    $ tar -xzf elasticsearch-5.5.0.tar.gz -C ~/chatbot_ner_elasticsearch/
+    $ ~/chatbot_ner_elasticsearch/elasticsearch-5.5.0/bin/elasticsearch -d
     ```
 
-     Elasticsearch will be extracted to `~/chatbot_ner_elasticsearch/elasticsearch-6.0.0/`
+     Elasticsearch will be extracted to `~/chatbot_ner_elasticsearch/elasticsearch-5.5.0/`
 
 
 7. Copy config.example to config and configure the settings for datastore

--- a/ner_v1/detectors/textual/text/text_detection.py
+++ b/ner_v1/detectors/textual/text/text_detection.py
@@ -331,17 +331,17 @@ class TextDetector(BaseDetector):
         # Length based ordering, this reorders the results from datastore
         # that are already sorted by some relevance scoring
 
-        # exact_matches, fuzzy_variants = [], []
-        # _text = u' '.join(TOKENIZER.tokenize(self.processed_text))
-        # for variant in variants_list:
-        #     if u' '.join(TOKENIZER.tokenize(variant)) in _text:
-        #         exact_matches.append(variant)
-        #     else:
-        #         fuzzy_variants.append(variant)
-        #
-        # exact_matches.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
-        # fuzzy_variants.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
-        # variants_list = exact_matches + fuzzy_variants
+        exact_matches, fuzzy_variants = [], []
+        _text = u' '.join(TOKENIZER.tokenize(self.processed_text))
+        for variant in variants_list:
+            if u' '.join(TOKENIZER.tokenize(variant)) in _text:
+                exact_matches.append(variant)
+            else:
+                fuzzy_variants.append(variant)
+
+        exact_matches.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
+        fuzzy_variants.sort(key=lambda s: len(TOKENIZER.tokenize(s)), reverse=True)
+        variants_list = exact_matches + fuzzy_variants
 
         for variant in variants_list:
             original_text = self._get_entity_substring_from_text(variant, self.processed_text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gunicorn==19.6.0
 pytz==2014.2
 nltk==3.2.5
 numpy==1.10.4
-elasticsearch==5.3.0
+elasticsearch==5.5.0
 requests==2.8.1
 requests-aws4auth==0.9
 django==1.8


### PR DESCRIPTION
because ES scoring involves length norms that assigns shorter terms higher score.
Also freeze ES version to 5.5.0