### PR TITLE
Fix some date patterns and add support for more range patterns

### DIFF
--- a/ner_v2/detectors/temporal/constant.py
+++ b/ner_v2/detectors/temporal/constant.py
@@ -54,7 +54,6 @@ TYPE_NEXT_DAY = 'day_in_next_week'
 TYPE_THIS_DAY = 'day_within_one_week'
 TYPE_POSSIBLE_DAY = 'possible_day'
 
-
 # ORIGINAL constants
 # TYPE_NEXT_DAY = 'next_day'
 # TYPE_CURRENT_DAY = 'current_day'
@@ -73,27 +72,27 @@ REPEAT_WEEKENDS = 'repeat_weekends'
 TYPE_REPEAT_DAY = 'repeat_day'
 
 MONTH_DICT = {
-    u'1': [u'jan', u'january'],
-    u'10': [u'october', u'oct'],
-    u'11': [u'november', u'nov'],
-    u'12': [u'december', u'dec'],
-    u'2': [u'february', u'feb'],
-    u'3': [u'mar', u'march'],
-    u'4': [u'apr', u'april'],
-    u'5': [u'may'],
-    u'6': [u'jun', u'june'],
-    u'7': [u'july', u'jul'],
-    u'8': [u'august', u'aug'],
-    u'9': [u'september', u'sept', u'sep']
+    1: [u'jan', u'january'],
+    10: [u'october', u'oct'],
+    11: [u'november', u'nov'],
+    12: [u'december', u'dec'],
+    2: [u'february', u'feb'],
+    3: [u'mar', u'march'],
+    4: [u'apr', u'april'],
+    5: [u'may'],
+    6: [u'jun', u'june'],
+    7: [u'july', u'jul'],
+    8: [u'august', u'aug'],
+    9: [u'september', u'sept', u'sep']
 }
 DAY_DICT = {
-    u'1': [u'sun', u'sunday'],
-    u'2': [u'mon', u'monday'],
-    u'3': [u'tuesday', u'tue'],
-    u'4': [u'wednesday', u'wed'],
-    u'5': [u'thu', u'thursday', u'thurs', u'thur'],
-    u'6': [u'fri', u'friday'],
-    u'7': [u'saturday', u'sat']
+    1: [u'sun', u'sunday'],
+    2: [u'mon', u'monday'],
+    3: [u'tuesday', u'tue'],
+    4: [u'wednesday', u'wed'],
+    5: [u'thu', u'thursday', u'thurs', u'thur'],
+    6: [u'fri', u'friday'],
+    7: [u'saturday', u'sat']
 }
 
 # CONSTANTS USED FOR DATE DETECTION
@@ -127,5 +126,5 @@ ORDINALS_MAP = {
     '9th': 9,
     'tenth': 10,
     '10th': 10,
-    'last': -1   # used to get last week of any month
+    'last': -1  # used to get last week of any month
 }

--- a/ner_v2/detectors/temporal/date/date_detection.py
+++ b/ner_v2/detectors/temporal/date/date_detection.py
@@ -211,7 +211,6 @@ class DateAdvancedDetector(BaseDetector):
 
         elif dd_mmm_to_dd_matches:
             for match in dd_mmm_to_dd_matches:
-                print('>>>', match)
                 date_dicts = self._date_dict_from_text(text=match[0])
                 if len(date_dicts) == 2:
                     date_dicts[0][temporal_constant.DATE_START_RANGE_PROPERTY] = True

--- a/ner_v2/detectors/temporal/date/date_detection.py
+++ b/ner_v2/detectors/temporal/date/date_detection.py
@@ -179,63 +179,68 @@ class DateAdvancedDetector(BaseDetector):
         regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])'
                                    r'\s?'
                                    r'(?:nd|st|rd|th)?'
-                                   r'\s?'
-                                   r'(?:to|\-|till)'
-                                   r'\s?'
+                                   r'(?:(?:\s*\-\s*)|\s+(?:to|till|se)\s+)'
                                    r'([12][0-9]|3[01]|0?[1-9])'
                                    r'\s?'
                                    r'(?:nd|st|rd|th)?'
-                                   r'[\ \,]'
-                                   r'\s?'
-                                   r'(?:of)?'
-                                   r'\s?'
+                                   r'[\s\,]+'
+                                   r'(?:of\s+)?'
                                    r'([A-Za-z]+))\b', flags=re.UNICODE)
 
         regex_pattern_2 = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])'
                                      r'\s?'
                                      r'(?:nd|st|rd|th)?'
-                                     r'\s+'
+                                     r'[\s\,]+'
+                                     r'(?:of\s+)?'
                                      r'([A-Za-z]+)'
-                                     r'\s+'
-                                     r'(?:to|\-|till)'
-                                     r'\s+'
+                                     r'(?:(?:\s*\-\s*)|\s+(?:to|till|se)\s+)'
                                      r'([12][0-9]|3[01]|0?[1-9])'
                                      r'\s?'
                                      r'(?:nd|st|rd|th)?'
-                                     r'\s?'
-                                     r'([a-zA-Z]+)?)\b', flags=re.UNICODE)
+                                     r'(?:[\s\,]+(?:of\s+)?([A-Za-z]+))?)\b', flags=re.UNICODE)
 
-        patterns = regex_pattern.findall(self.processed_text.lower())
-        patterns_2 = regex_pattern_2.findall(self.processed_text.lower())
-        if patterns:
-            for pattern in patterns:
-                date_dicts = self._date_dict_from_text(text=pattern[0])
+        dd_to_dd_mmm_matches = regex_pattern.findall(self.processed_text)
+        dd_mmm_to_dd_matches = regex_pattern_2.findall(self.processed_text)
+        if dd_to_dd_mmm_matches:
+            for match in dd_to_dd_mmm_matches:
+                date_dicts = self._date_dict_from_text(text=match[0])
                 if len(date_dicts) == 2:
                     date_dicts[0][temporal_constant.DATE_START_RANGE_PROPERTY] = True
                     date_dicts[1][temporal_constant.DATE_END_RANGE_PROPERTY] = True
                     date_dict_list.extend(date_dicts)
 
-        elif patterns_2:
-            for pattern in patterns_2:
-                date_dicts = self._date_dict_from_text(text=pattern[0])
+        elif dd_mmm_to_dd_matches:
+            for match in dd_mmm_to_dd_matches:
+                print('>>>', match)
+                date_dicts = self._date_dict_from_text(text=match[0])
                 if len(date_dicts) == 2:
                     date_dicts[0][temporal_constant.DATE_START_RANGE_PROPERTY] = True
                     date_dicts[1][temporal_constant.DATE_END_RANGE_PROPERTY] = True
                     date_dict_list.extend(date_dicts)
         else:
-            parts = re.split(r'\s+(?:\-|to|se)\s+', self.processed_text.lower())
-            if len(parts) > 1:
-                for start_part, end_part in zip(parts[:-1], parts[1:]):
-                    start_date_list = self._date_dict_from_text(text=start_part, start_range_property=True)
-                    end_date_list = self._date_dict_from_text(text=end_part, end_range_property=True)
-                    if start_date_list and end_date_list:
-                        start_date_list, end_date_list = self._generate_range(start_date_dict=start_date_list[0],
-                                                                              end_date_dict=end_date_list[-1])
-                        date_dict_list.extend(start_date_list)
-                        date_dict_list.extend(end_date_list)
+            parts = iter(re.split(r'\s+(?:\-|to|till|se)\s+', self.processed_text))
+            _day_of_week_types = [temporal_constant.TYPE_THIS_DAY, temporal_constant.TYPE_NEXT_DAY]
+            for start_part, end_part in zip(parts, parts):  # Consumes 2 items at a time from parts
+                start_date_list = self._date_dict_from_text(text=start_part, start_range_property=True)
+                end_date_list = self._date_dict_from_text(text=end_part, end_range_property=True)
+                if start_date_list and end_date_list:
+                    possible_start_date = start_date_list[0]
+                    possible_end_date = end_date_list[-1]
+                    start_date_type = possible_start_date[temporal_constant.DATE_VALUE]['type']
+                    end_date_type = possible_end_date[temporal_constant.DATE_VALUE]['type']
+                    if start_date_type in _day_of_week_types and end_date_type in _day_of_week_types:
+                        start_date_list, end_date_list = self._fix_day_range(start_date_dict=possible_start_date,
+                                                                             end_date_dict=possible_end_date)
+                    else:
+                        # FIXME: Assumes end_date > start_date. Also can return dates in past when date detector
+                        # returns dates in the past
+                        start_date_list = [possible_start_date]
+                        end_date_list = [possible_end_date]
+                    date_dict_list.extend(start_date_list)
+                    date_dict_list.extend(end_date_list)
         return date_dict_list
 
-    def _generate_range(self, start_date_dict, end_date_dict):
+    def _fix_day_range(self, start_date_dict, end_date_dict):
         """
         If today is between the detected range, generate two day ranges - range for current week and the same range
         for next week, other wise both start date and end date dicts are returned as only elements of start date list
@@ -298,14 +303,15 @@ class DateAdvancedDetector(BaseDetector):
             For departure date the key "From" will be set to True.
         """
         date_dict_list = []
-        regex_pattern = re.compile(r'\b((onward date\:|onward date -|departure date|leaving on|starting from|'
-                                   r'departing on|departing|going on|for|departs on)\s+(.+))\b', flags=re.UNICODE)
-        patterns = regex_pattern.findall(self.processed_text.lower())
+        regex_pattern = re.compile(r'\b'
+                                   r'(?:check(?:\s|\-)?in date (?:is|\:)?|'
+                                   r'onward date\s?(?:\:|\-)?|departure date|leaving on|starting from|'
+                                   r'departing on|departing|going on|departs on|for)'
+                                   r'\s+(.+?)(?:\band|&|(?<!\d)\.|$)', flags=re.UNICODE)
+        matches = regex_pattern.findall(self.processed_text)
 
-        for pattern in patterns:
-            date_dict_list.extend(
-                self._date_dict_from_text(text=pattern[2], from_property=True)
-            )
+        for match in matches:
+            date_dict_list.extend(self._date_dict_from_text(text=match, from_property=True))
         return date_dict_list
 
     def _detect_return_date(self):
@@ -322,21 +328,24 @@ class DateAdvancedDetector(BaseDetector):
         """
 
         date_dict_list = []
-        regex_pattern_1 = re.compile(r'\s?((coming back|back|return date\:?|return date -|returning on|'
-                                     r'arriving|arrive|return|returning at)\s+(.+))\.?\s?', flags=re.UNICODE)
-        regex_pattern_2 = re.compile(r'(.+)\s+(ko|k|)\s*(aana|ana|aunga|aaun)', flags=re.UNICODE)
-        patterns_1 = regex_pattern_1.findall(self.processed_text.lower())
-        patterns_2 = regex_pattern_2.findall(self.processed_text.lower())
-        if patterns_1:
-            for pattern in patterns_1:
-                date_dict_list.extend(
-                    self._date_dict_from_text(text=pattern[2], to_property=True)
-                )
-        elif patterns_2:
-            for pattern in patterns_2:
-                date_dict_list.extend(
-                    self._date_dict_from_text(text=pattern[0], to_property=True)
-                )
+        regex_pattern_1 = re.compile(r'\b'
+                                     r'(?:check(?:\s|\-)?out date (?:is|\:)?|'
+                                     r'coming back|return date\s?(?:\:|\-)?|returning on|returning at|'
+                                     r'arriving|arrive|return|back)'
+                                     r'\s+(.+?)(?:\band|&|(?<!\d)\.|$)', flags=re.UNICODE)
+        regex_pattern_2 = re.compile(r'(.+?)\s+(?:ko?\s+)?(?:aana|ana|aunga|aaun)', flags=re.UNICODE)
+        matches = None
+        matches_1 = regex_pattern_1.findall(self.processed_text)
+        matches_2 = regex_pattern_2.findall(self.processed_text)
+
+        if matches_1:
+            matches = matches_1
+        elif matches_2:
+            matches = matches_2
+
+        matches = matches or []
+        for match in matches:
+            date_dict_list.extend(self._date_dict_from_text(text=match, to_property=True))
         return date_dict_list
 
     def _detect_any_date(self):
@@ -357,7 +366,6 @@ class DateAdvancedDetector(BaseDetector):
             Whereas for arrival date the key "to" will be set to True.
             Otherwise the normal date with the key 'normal' will be set to True
         """
-        date_dict_list = []
         departure_date_flag = False
         return_date_flag = False
         if self.bot_message:
@@ -378,22 +386,18 @@ class DateAdvancedDetector(BaseDetector):
             elif arrival_regexp.search(self.bot_message) is not None:
                 return_date_flag = True
 
-        patterns = re.compile(r'\s((.+))\.?', flags=re.UNICODE).findall(self.processed_text.lower())
-
-        for pattern in patterns:
-            pattern = list(pattern)
-            date_dict_list = self._date_dict_from_text(text=pattern[1])
-            if date_dict_list:
-                if len(date_dict_list) > 1:
-                    for i in range(len(date_dict_list)):
-                        date_dict_list[i][temporal_constant.DATE_NORMAL_PROPERTY] = True
+        date_dict_list = self._date_dict_from_text(text=self.processed_text)
+        if date_dict_list:
+            if len(date_dict_list) > 1:
+                for i in range(len(date_dict_list)):
+                    date_dict_list[i][temporal_constant.DATE_NORMAL_PROPERTY] = True
+            else:
+                if departure_date_flag:
+                    date_dict_list[0][temporal_constant.DATE_FROM_PROPERTY] = True
+                elif return_date_flag:
+                    date_dict_list[0][temporal_constant.DATE_TO_PROPERTY] = True
                 else:
-                    if departure_date_flag:
-                        date_dict_list[0][temporal_constant.DATE_FROM_PROPERTY] = True
-                    elif return_date_flag:
-                        date_dict_list[0][temporal_constant.DATE_TO_PROPERTY] = True
-                    else:
-                        date_dict_list[0][temporal_constant.DATE_NORMAL_PROPERTY] = True
+                    date_dict_list[0][temporal_constant.DATE_NORMAL_PROPERTY] = True
         return date_dict_list
 
     def _update_processed_text(self, date_dict_list):

--- a/ner_v2/detectors/temporal/date/en/date_detection.py
+++ b/ner_v2/detectors/temporal/date/en/date_detection.py
@@ -1736,7 +1736,7 @@ class DateDetector(object):
         regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?'
                                    r'(?:(?:\s*\-\s*)|\s+(?:to|till|se)\s+)'
                                    r'([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?[\s\,]+(?:of\s+)?'
-                                   r'(?:next|nxt|comm?ing?|foll?owing?)?\s+(?:mo?nth))\b')
+                                   r'(?:next|nxt|comm?ing?|foll?owing?)\s+(?:mo?nth))\b')
         patterns = regex_pattern.findall(self.processed_text.lower())
         for pattern in patterns:
             original = pattern[0]
@@ -1862,6 +1862,7 @@ class DateDetector(object):
         return date_list, original_list
 
     def __get_month_index(self, value):
+        # type: (str) -> Optional[int]
         """
         Gets the index of month by comparing the value with month names and their variants from the data store
 
@@ -1878,6 +1879,7 @@ class DateDetector(object):
         return None
 
     def __get_day_index(self, value):
+        # type: (str) -> Optional[int]
         """
         Gets the index of month by comparing the value with day names and their variants from the data store
 

--- a/ner_v2/detectors/temporal/date/en/date_detection.py
+++ b/ner_v2/detectors/temporal/date/en/date_detection.py
@@ -8,7 +8,7 @@ from chatbot_ner.config import ner_logger
 from ner_v2.detectors.temporal.constant import TYPE_EXACT, TYPE_EVERYDAY, TYPE_TODAY, TYPE_TOMORROW, TYPE_YESTERDAY, \
     TYPE_DAY_AFTER, TYPE_DAY_BEFORE, TYPE_N_DAYS_AFTER, TYPE_NEXT_DAY, TYPE_THIS_DAY, TYPE_POSSIBLE_DAY, WEEKDAYS, \
     REPEAT_WEEKDAYS, WEEKENDS, REPEAT_WEEKENDS, TYPE_REPEAT_DAY, MONTH_DICT, DAY_DICT, ORDINALS_MAP
-from ner_v2.detectors.temporal.utils import get_weekdays_for_month
+from ner_v2.detectors.temporal.utils import get_weekdays_for_month, get_next_date_with_dd, get_previous_date_with_dd
 
 
 class DateDetector(object):
@@ -164,8 +164,7 @@ class DateDetector(object):
         self._update_processed_text(original_list)
         date_list, original_list = self._date_range_ddth_of_mmm_to_ddth(date_list, original_list)
         self._update_processed_text(original_list)
-        date_list, original_list = self._date_range_ddth_to_ddth_of_next_month(date_list,
-                                                                               original_list)
+        date_list, original_list = self._date_range_ddth_to_ddth_of_next_month(date_list, original_list)
         self._update_processed_text(original_list)
         date_list, original_list = self._gregorian_day_with_ordinals_month_year_format(date_list, original_list)
         self._update_processed_text(original_list)
@@ -230,6 +229,8 @@ class DateDetector(object):
         self._update_processed_text(original_list)
         date_list, original_list = self._date_identification_given_day(date_list, original_list)
         self._update_processed_text(original_list)
+        # FIXME: This call order causes everyday to be taken away from "everyday except <>" which means
+        # FIXME: successive calls for everyday_except_weekends and everyday_except_weekdays return wrong results
         date_list, original_list = self._date_identification_everyday(date_list, original_list, n_days=15)
         self._update_processed_text(original_list)
         date_list, original_list = self._date_identification_everyday_except_weekends(date_list, original_list,
@@ -289,14 +290,16 @@ class DateDetector(object):
             original_list = []
         if date_list is None:
             date_list = []
-        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?[/\-\.]\s?(1[0-2]|0?[1-9])\s?[/\-\.]'
-                                   r'\s?((?:20|19)?[0-9]{2}))(\s|$)')
+        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?[/\-\.]\s?(1[0-2]|0?[1-9])'
+                                   r'(?:\s?[/\-\.]\s?((?:20|19)?[0-9]{2}))?)(?:\s|$)')
         patterns = regex_pattern.findall(self.processed_text.lower())
         for pattern in patterns:
             original = pattern[0]
-            dd = pattern[1]
-            mm = pattern[2]
-            yy = self.normalize_year(pattern[3])
+            dd = int(pattern[1])
+            mm = int(pattern[2])
+            yy = int(self.normalize_year(pattern[3])) if pattern[3] else self.now_date.year
+            if not pattern[3] and self.timezone.localize(datetime.datetime(year=yy, month=mm, day=dd)) < self.now_date:
+                yy += 1
 
             date = {
                 'dd': int(dd),
@@ -493,8 +496,8 @@ class DateDetector(object):
             date_list = []
         if original_list is None:
             original_list = []
-        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?\s?(?:of)?[\s\,]\s?'
-                                   r'([A-Za-z]+)[\s\,]\s?((?:20|19)?[0-9]{2}))(\s|$)')
+        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?\s?(?:of)?[\s\,\-]\s?'
+                                   r'([A-Za-z]+)[\s\,\-]\s?((?:20|19)?[0-9]{2}))(\s|$)')
         patterns = regex_pattern.findall(self.processed_text.lower())
         for pattern in patterns:
             original = pattern[0].strip()
@@ -647,8 +650,8 @@ class DateDetector(object):
             original_list = []
         if date_list is None:
             date_list = []
-        regex_pattern = re.compile(r'\b(([A-Za-z]+)[\ \,]\s?([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?'
-                                   r'[\ \,]\s?((?:20|19)?[0-9]{2}))(\s|$)')
+        regex_pattern = re.compile(r'\b(([A-Za-z]+)[\ \,\-]\s?([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?'
+                                   r'[\ \,\-]\s?((?:20|19)?[0-9]{2}))(\s|$)')
         patterns = regex_pattern.findall(self.processed_text.lower())
         for pattern in patterns:
             original = pattern[0]
@@ -1073,7 +1076,8 @@ class DateDetector(object):
             day = self.__get_day_index(probable_day)
             current_day = self.__get_day_index(self.now_date.strftime("%A"))
             if day and current_day:
-                date_after_days = int(day) - int(current_day) + 7
+                day, current_day = int(day), int(current_day)
+                date_after_days = day - current_day + 7
                 day_to_set = self.now_date + datetime.timedelta(days=date_after_days)
                 dd = day_to_set.day
                 mm = day_to_set.month
@@ -1124,10 +1128,11 @@ class DateDetector(object):
             day = self.__get_day_index(probable_day)
             current_day = self.__get_day_index(self.now_date.strftime("%A"))
             if day and current_day:
-                if int(current_day) <= int(day):
-                    date_after_days = int(day) - int(current_day)
+                day, current_day = int(day), int(current_day)
+                if current_day <= day:
+                    date_after_days = day - current_day
                 else:
-                    date_after_days = int(day) - int(current_day) + 7
+                    date_after_days = day - current_day + 7
                 day_to_set = self.now_date + datetime.timedelta(days=date_after_days)
                 dd = day_to_set.day
                 mm = day_to_set.month
@@ -1372,11 +1377,11 @@ class DateDetector(object):
             date_list = []
         now = self.now_date
         end = now + datetime.timedelta(days=n_days)
-        regex_pattern = re.compile(r'\b(([eE]veryday|[dD]aily)|all\sdays[\s]?except[\s]?([wW]eekend|[wW]eekends))\b')
+        regex_pattern = re.compile(r'\b((every\s?day|daily|all\s?days)\s+except\s+weekends?)\b')
         patterns = regex_pattern.findall(self.processed_text.lower())
 
         if not patterns:
-            weekday_regex_pattern = re.compile(r'\b(weekdays|weekday|week day|week days| all weekdays)\b')
+            weekday_regex_pattern = re.compile(r'\b((week\s?days?|all\sweekdays))\b')
             patterns = weekday_regex_pattern.findall(self.processed_text.lower())
         constant_type = WEEKDAYS
         if self._is_everyday_present(self.text):
@@ -1450,11 +1455,10 @@ class DateDetector(object):
             original_list = []
         now = self.now_date
         end = now + datetime.timedelta(days=n_days)
-        regex_pattern = re.compile(r'\b(([eE]veryday|[dD]aily)|[eE]very\s*day|all[\s]?except[\s]?'
-                                   r'([wW]eekday|[wW]eekdays))\b')
+        regex_pattern = re.compile(r'\b((every\s?day|daily|all\s?days)\s+except\s+weekdays?)\b')
         patterns = regex_pattern.findall(self.processed_text.lower())
         if not patterns:
-            weekend_regex_pattern = re.compile(r'\b((weekends|weekend|week end|week ends | all weekends))\b')
+            weekend_regex_pattern = re.compile(r'\b((week\s?ends?|all\sweekends))\b')
             patterns = weekend_regex_pattern.findall(self.processed_text.lower())
         constant_type = WEEKENDS
         if self._is_everyday_present(self.text):
@@ -1528,29 +1532,36 @@ class DateDetector(object):
             original_list = []
         if date_list is None:
             date_list = []
-        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?\s?(?:-|to|-|till)\s?'
-                                   r'([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?[\ \,]\s?(?:of)?\s?([A-Za-z]+))\b')
+        # FIXME: This ignores any mentioned year
+        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s*(?:nd|st|rd|th)?'
+                                   r'(?:(?:\s*\-\s*)|\s+(?:to|till|se)\s+)'
+                                   r'([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?[\s\,]+(?:of\s+)?([A-Za-z]+))\b')
         patterns = regex_pattern.findall(self.processed_text.lower())
         for pattern in patterns:
             original = pattern[0]
-            dd1 = pattern[1]
-            dd2 = pattern[2]
-            probable_mm = pattern[3]
-            mm = self.__get_month_index(probable_mm)
-            yy = self.now_date.year
-            if mm:
-                if self.now_date.month > int(mm):
-                    yy += 1
+            dd1, mm1, yy1 = int(pattern[1]), None, None
+            dd2, mm2, yy2 = int(pattern[2]), self.__get_month_index(pattern[3]), self.now_date.year
+
+            if mm2:
+                mm2 = int(mm2)
+                dt2 = self.timezone.localize(datetime.datetime(year=yy2, month=mm2, day=dd2))
+                dd1, mm1, yy1 = get_previous_date_with_dd(dd=dd1, before_datetime=dt2)
+                if dd1 and mm1 and yy1:
+                    dt1 = self.timezone.localize(datetime.datetime(year=yy1, month=mm1, day=dd1))
+                    if dt1 < self.now_date:
+                        yy1 = yy2 = yy2 + 1
+
+            if all(part for part in [dd1, mm1, yy1, dd2, mm2, yy2]):
                 date_dict_1 = {
                     'dd': int(dd1),
-                    'mm': int(mm),
-                    'yy': int(yy),
+                    'mm': int(mm1),
+                    'yy': int(yy1),
                     'type': TYPE_EXACT
                 }
                 date_dict_2 = {
                     'dd': int(dd2),
-                    'mm': int(mm),
-                    'yy': int(yy),
+                    'mm': int(mm2),
+                    'yy': int(yy2),
                     'type': TYPE_EXACT
                 }
                 date_list.append(date_dict_1)
@@ -1589,7 +1600,7 @@ class DateDetector(object):
         if date_list is None:
             date_list = []
         ordinal_choices = "|".join(ORDINALS_MAP.keys())
-        regex_pattern = re.compile(r'((' + ordinal_choices + ')\s+week\s+(of\s+)?([a-zA-z]+)(?:\s+month)?)\s+')
+        regex_pattern = re.compile(r'((' + ordinal_choices + r')\s+week\s+(of\s+)?([A-Za-z]+)(?:\s+month)?)\s+')
         patterns = regex_pattern.findall(self.processed_text.lower())
         for pattern in patterns:
             original = pattern[0]
@@ -1647,45 +1658,33 @@ class DateDetector(object):
             original_list = []
         if date_list is None:
             date_list = []
-        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?\s+(?:of\s+)?([A-Za-z]+)\s+'
-                                   r'(?:-|to|-|till)\s+([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?\s?([a-zA-Z]+)?)\b')
+        # FIXME: This ignores any mentioned year
+        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?[\s\,]+(?:of\s+)?([A-Za-z]+)'
+                                   r'(?:(?:\s*\-\s*)|\s+(?:to|till|se)\s+)'
+                                   r'([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?'
+                                   r'(?:[\s\,]+(?:of\s+)?([A-Za-z]+))?)\b')
         patterns = regex_pattern.findall(self.processed_text.lower())
         for pattern in patterns:
             original = pattern[0]
-            dd1 = int(pattern[1])
-            dd2 = int(pattern[3])
-            probable_mm1 = pattern[2]
-            probable_mm2 = pattern[4]
-            mm1 = self.__get_month_index(probable_mm1)
-            mm2_mention = self.__get_month_index(probable_mm2)
-
-            mm2 = mm2_mention
-            if not mm2:
-                mm2 = mm1
-
-            yy1 = self.now_date.year
-
-            if mm1 and mm2:
+            dd1, mm1, yy1 = int(pattern[1]), self.__get_month_index(pattern[2]), self.now_date.year
+            dd2, mm2, yy2 = int(pattern[3]), self.__get_month_index(pattern[4]), self.now_date.year
+            if mm1:
                 mm1 = int(mm1)
-                mm2 = int(mm2)
-
-                if not mm2_mention and dd2 < dd1:
-                    mm2 += 1
-                    if mm2 > 12:
-                        mm2 = 1
-
                 dt1 = self.timezone.localize(datetime.datetime(year=yy1, month=mm1, day=dd1))
-
                 if dt1 < self.now_date:
-                    yy1 += 1
+                    yy2 = yy1 = yy1 + 1
+                    dt1 = self.timezone.localize(datetime.datetime(year=yy1, month=mm1, day=dd1))
 
-                yy2 = yy1
-                dt1 = self.timezone.localize(datetime.datetime(year=yy1, month=mm1, day=dd1))
-                dt2 = self.timezone.localize(datetime.datetime(year=yy2, month=mm2, day=dd2))
+                if mm2:
+                    # find the correct yy2 such that dd2/mm2/yy2 >= dd1/mm1/yy1
+                    mm2 = int(mm2)
+                    dt2 = self.timezone.localize(datetime.datetime(year=yy2, month=mm2, day=dd2))
+                    yy2 = yy2 + 1 if dt2 < dt1 else yy2
+                else:
+                    # find the closest dd2 after dt1
+                    dd2, mm2, yy2 = get_next_date_with_dd(dd=dd2, after_datetime=dt1)
 
-                if dt2 < dt1:
-                    yy2 += 1
-
+            if all(part for part in [dd1, mm1, yy1, dd2, mm2, yy2]):
                 date_dict_1 = {
                     'dd': int(dd1),
                     'mm': int(mm1),
@@ -1734,9 +1733,10 @@ class DateDetector(object):
             original_list = []
         if date_list is None:
             date_list = []
-        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?\s+(?:-|to|-|till)\s+'
-                                   r'([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?[\ \,\s]+(?:of\s+)?'
-                                   r'(?:next|nxt|comm?ing?|foll?owing?|)\s+(?:mo?nth))\b')
+        regex_pattern = re.compile(r'\b(([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?'
+                                   r'(?:(?:\s*\-\s*)|\s+(?:to|till|se)\s+)'
+                                   r'([12][0-9]|3[01]|0?[1-9])\s?(?:nd|st|rd|th)?[\s\,]+(?:of\s+)?'
+                                   r'(?:next|nxt|comm?ing?|foll?owing?)?\s+(?:mo?nth))\b')
         patterns = regex_pattern.findall(self.processed_text.lower())
         for pattern in patterns:
             original = pattern[0]

--- a/ner_v2/detectors/temporal/utils.py
+++ b/ner_v2/detectors/temporal/utils.py
@@ -9,6 +9,7 @@ from ner_v2.detectors.temporal.constant import POSITIVE_TIME_DIFF, NEGATIVE_TIME
 def nth_weekday(weekday, n, ref_date):
     """
     Method to return python datetime object for given nth weekday w.r.t ref_date (reference date)
+
     Args:
         weekday (int): int count of weekday like 0 for monday, 1 for tuesday
         n (int): nth weekday
@@ -26,6 +27,7 @@ def nth_weekday(weekday, n, ref_date):
 def next_weekday(current_date, weekday, n):
     """
     Method to return python datetime object to find next weekday from current date
+
     Args:
         current_date (datetime): python datetime object
         weekday (int): int count of weekday like 0 for monday, 1 for tuesday
@@ -44,9 +46,11 @@ def next_weekday(current_date, weekday, n):
 def get_hour_min_diff(time1, time2):
     """
     Method to return difference between two times in hours and minutes.
+
     Args:
         time1 (datetime): datetime object
         time2 (datetime): datetime object
+
     Returns:
         hh (int): hour difference between two times
         mm (int): minute difference between two times
@@ -66,6 +70,7 @@ def get_hour_min_diff(time1, time2):
 def get_tuple_dict(csv_file):
     """
     Method to convert language constant csv into tuple dict
+
     Args:
         csv_file (str): csv file path
 
@@ -87,10 +92,12 @@ def get_tuple_dict(csv_file):
 def get_weekdays_for_month(weeknumber, month, year):
     """
     Return list of day for given weeknumber of given month and year
+
     Args:
         weeknumber (int): week number
         month (int): month
         year (int): year
+
     Returns:
         (list): list of days
     """
@@ -103,12 +110,27 @@ def get_weekdays_for_month(weeknumber, month, year):
 
 
 def is_valid_date(dd, mm, yy, tz=None):
-    # type: (int, int, int, pytz.tzfile.*) -> bool
+    # type: (int, int, int, 'pytz.tzfile.*') -> bool
+    """
+    Given dd, mm, yy check if it is a valid date in a year
+
+    Args:
+        dd (int): upto 2 digit integer
+        mm (int): upto 2 digit integer
+        yy (int): upto 4 digit integer
+        tz (pytz.tzfile.*, optional): A valid pytz timezone. defaults to None
+
+    Returns:
+        bool: if dd/mm/yy is a valid date
+
+    Raises:
+        TypeError: when any of dd, mm, yy is not an int
+    """
     if dd and mm and yy:
         try:
             dt = datetime(year=yy, month=mm, day=dd)
             if tz:
-                dt = tz.localize(dt)
+                tz.localize(dt)
             return True
         except (ValueError, AttributeError):
             pass
@@ -117,6 +139,22 @@ def is_valid_date(dd, mm, yy, tz=None):
 
 def get_previous_month_number(mm, yy):
     # type: (int, int) -> Tuple[int, int]
+    """
+    Given month number and year get previous month number and adjust year if we flow into previous year
+
+    Args:
+        mm (int): upto 2 digit month number, between 1 and 12
+        yy (int): any year
+
+    Returns:
+        tuple: tuple containing
+            int: previous month number after mm
+            int: adjusted year for the previous month number
+
+    Raises:
+        ValueError: when mm is not between 1 and 12
+
+    """
     if 1 <= mm <= 12:
         if mm == 1:
             mm = 12
@@ -131,6 +169,22 @@ def get_previous_month_number(mm, yy):
 
 def get_next_month_number(mm, yy):
     # type: (int, int) -> Tuple[int, int]
+    """
+    Given month number and year get next month number and adjust year if we flow into next year
+
+    Args:
+        mm (int): upto 2 digit month number, between 1 and 12
+        yy (int): any year
+
+    Returns:
+        tuple: tuple containing
+            int: next month number after mm
+            int: adjusted year for the next month number
+
+    Raises:
+        ValueError: when mm is not between 1 and 12
+
+    """
     if 1 <= mm <= 12:
         if mm == 12:
             mm = 1
@@ -145,6 +199,21 @@ def get_next_month_number(mm, yy):
 
 def get_previous_date_with_dd(dd, before_datetime):
     # type: (int, datetime.datetime) -> Tuple[Optional[int], Optional[int], Optional[int]]
+    """
+    Get closest date with day same as `dd` on or before `before_datetime`
+
+    Args:
+        dd (int): 2 digit int, expected between 1 and 31
+        before_datetime (datetime.datetime): python datetime object, the date to look back from
+
+    Returns:
+        tuple: tuple containing
+            int or None: day part of found date, if no such valid date can be found None
+            int or None: month part of found date, if no such valid date can be found None
+            int or None: year part of found date, if no such valid date can be found None
+
+    """
+
     end_dd = before_datetime.day
     mm = before_datetime.month
     yy = before_datetime.year
@@ -163,6 +232,20 @@ def get_previous_date_with_dd(dd, before_datetime):
 
 def get_next_date_with_dd(dd, after_datetime):
     # type: (int, datetime.datetime) -> Tuple[Optional[int], Optional[int], Optional[int]]
+    """
+    Get closest date with day same as `dd` on or after `after_datetime`
+
+    Args:
+        dd (int): 2 digit int, expected between 1 and 31
+        after_datetime (datetime.datetime): python datetime object, the date to look ahead from
+
+    Returns:
+        tuple: tuple containing
+            int or None: day part of found date, if no such valid date can be found None
+            int or None: month part of found date, if no such valid date can be found None
+            int or None: year part of found date, if no such valid date can be found None
+
+    """
     start_dd = after_datetime.day
     mm = after_datetime.month
     yy = after_datetime.year


### PR DESCRIPTION
Detailed Changelog

ner_v2.detectors.temporal.date.en.date_detection.DateDetector

- Make year optional in dd/mm/yy (`_gregorian_day_month_year_format`)
- Add support for "-" in dd-mmm-yy format (`_gregorian_day_with_ordinals_month_year_format`)
- Add support for "-" in mmm-dd-yy format (`_gregorian_month_day_with_ordinals_year_format`)
- Make pattern for `_day_month_format_for_arrival_departure` more robust and add range fixing logic
- Make pattern for `_date_range_ddth_of_mmm_to_ddth` more robust and simplify range fixing logic
- Make pattern for `_date_range_ddth_to_ddth_of_next_month` more robust
- Simplify and correct patterns for `_date_identification_everyday_except_weekends` and `_date_identification_everyday_except_weekdays` to get correct original_text
- Fix pattern warning in `_day_range_for_nth_week_month`
- `__get_month_index` and `__get_day_index` now return `int` instead of `str`
- Add various fixme, todo, notes for known issues

chatbot_ner.ner_v2.detectors.temporal.utils

- Add 5 helper methods
    * is_valid_date
    * get_previous_month_number
    * get_next_month_number
    * get_previous_date_with_dd
    * get_next_date_with_dd

ner_v2.detectors.temporal.constant

- MONTH_DICT AND DAY_DICT now have integer keys

ner_v2.detectors.temporal.date.date_detection.DateAdvancedDetector

- Make pattern for `dd th to dd th mmm` more robust
- Make pattern for `dd th mmm to dd th mmm?` more robust
- Two week ranges are only generated now if date type was THIS_DAY or NEXT_DAY
- Change part generation logic in generic range detection
- `_generate_range` renamed to `_fix_day_range`
- Simplify pattern in `_detect_departure_date` and add few variants
- Fix and Simplify patterns in `_detect_return_date` and add few variants
- Remove redundant logic from `_detect_any_date`