### PR TITLE
Detect ranges correctly when there are multiple separators

### DIFF
--- a/ner_v2/detectors/temporal/date/date_detection.py
+++ b/ner_v2/detectors/temporal/date/date_detection.py
@@ -1,12 +1,13 @@
 # coding=utf-8
-import itertools
+from __future__ import absolute_import
 
-import six
 import copy
 import datetime
 import importlib
 import os
 import re
+
+import six
 
 import models.crf.constant as model_constant
 import ner_v2.detectors.temporal.constant as temporal_constant

--- a/ner_v2/detectors/temporal/date/date_detection.py
+++ b/ner_v2/detectors/temporal/date/date_detection.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+import itertools
+
 import six
 import copy
 import datetime
@@ -216,31 +218,32 @@ class DateAdvancedDetector(BaseDetector):
                     date_dicts[1][temporal_constant.DATE_END_RANGE_PROPERTY] = True
                     date_dict_list.extend(date_dicts)
         else:
-            parts = re.split(r'\s+(?:\-|to|till|se)\s+', self.processed_text)
-            skip_next_pair = False
-            _day_of_week_types = [temporal_constant.TYPE_THIS_DAY, temporal_constant.TYPE_NEXT_DAY]
-            for start_part, end_part in six.moves.zip(parts, parts[1:]):
-                if skip_next_pair:
-                    continue
+            for sentence_part in re.split(r'\s+(?:and|aur|&|or)\s+', self.processed_text):
+                parts = re.split(r'\s+(?:\-|to|till|se)\s+', sentence_part)
                 skip_next_pair = False
-                start_date_list = self._date_dict_from_text(text=start_part, start_range_property=True)
-                end_date_list = self._date_dict_from_text(text=end_part, end_range_property=True)
-                if start_date_list and end_date_list:
-                    possible_start_date = start_date_list[0]
-                    possible_end_date = end_date_list[-1]
-                    start_date_type = possible_start_date[temporal_constant.DATE_VALUE]['type']
-                    end_date_type = possible_end_date[temporal_constant.DATE_VALUE]['type']
-                    if start_date_type in _day_of_week_types and end_date_type in _day_of_week_types:
-                        start_date_list, end_date_list = self._fix_day_range(start_date_dict=possible_start_date,
-                                                                             end_date_dict=possible_end_date)
-                    else:
-                        # FIXME: Assumes end_date > start_date. Also can return dates in past when date detector
-                        # returns dates in the past
-                        start_date_list = [possible_start_date]
-                        end_date_list = [possible_end_date]
-                    date_dict_list.extend(start_date_list)
-                    date_dict_list.extend(end_date_list)
-                    skip_next_pair = True
+                _day_of_week_types = [temporal_constant.TYPE_THIS_DAY, temporal_constant.TYPE_NEXT_DAY]
+                for start_part, end_part in six.moves.zip(parts, parts[1:]):
+                    if skip_next_pair:
+                        skip_next_pair = False
+                        continue
+                    start_date_list = self._date_dict_from_text(text=start_part, start_range_property=True)
+                    end_date_list = self._date_dict_from_text(text=end_part, end_range_property=True)
+                    if start_date_list and end_date_list:
+                        possible_start_date = start_date_list[0]
+                        possible_end_date = end_date_list[-1]
+                        start_date_type = possible_start_date[temporal_constant.DATE_VALUE]['type']
+                        end_date_type = possible_end_date[temporal_constant.DATE_VALUE]['type']
+                        if start_date_type in _day_of_week_types and end_date_type in _day_of_week_types:
+                            start_date_list, end_date_list = self._fix_day_range(start_date_dict=possible_start_date,
+                                                                                 end_date_dict=possible_end_date)
+                        else:
+                            # FIXME: Assumes end_date > start_date. Also can return dates in past when date detector
+                            # returns dates in the past
+                            start_date_list = [possible_start_date]
+                            end_date_list = [possible_end_date]
+                        date_dict_list.extend(start_date_list)
+                        date_dict_list.extend(end_date_list)
+                        skip_next_pair = True
         return date_dict_list
 
     def _fix_day_range(self, start_date_dict, end_date_dict):


### PR DESCRIPTION
Detect start date and end date correctly in cases like

'I want to book travel from 13.05.19 to 15.06.19'
'I want to book travel from 13.05.19 to 15.06.19 and 17.06.19 to 18.07.19'
'I want to book travel from 13.05.19 to 15.06.19 to 17.06.19 to 18.07.19'

The approach is to first split by 'and' and 'or', then process each part by finding pairs and avoiding overlaps