### PR TITLE
Fix scale search and add test cases for all scales of budgets

### DIFF
--- a/ner_v1/detectors/numeral/budget/budget_detection.py
+++ b/ner_v1/detectors/numeral/budget/budget_detection.py
@@ -119,8 +119,8 @@ class BudgetDetector(BaseDetector):
         self.tag = '__' + self.entity_name + '__'
         self._use_text_detection = use_text_detection
 
-        scales, units = zip(*sorted(
-            list(BudgetDetector._scale_patterns.items()), key=lambda scale_pattern: len(scale_pattern[1]), reverse=True
+        units, scales = zip(*sorted(
+            list(BudgetDetector._scale_patterns.items()), key=lambda pattern_scale: len(pattern_scale[0]), reverse=True
         ))
         self._scale_compiled_patterns = [(scale, re.compile(unit)) for scale, unit in zip(scales, units)]
         digits_pattern = r'((?:\d+(?:\,\d+)*(?:\.\d+)?)|(?:(?:\d+(?:\,\d+)*)?(?:\.\d+)))'

--- a/ner_v1/detectors/numeral/budget/budget_detection.py
+++ b/ner_v1/detectors/numeral/budget/budget_detection.py
@@ -77,6 +77,24 @@ class BudgetDetector(BaseDetector):
 
     """
 
+    _scale_patterns = {
+        'k': 1000,
+        'ha?zaa?r': 1000,
+        'ha?ja?ar': 1000,
+        'thousa?nd': 1000,
+        'l': 100000,
+        'lacs?': 100000,
+        'lakh?s?': 100000,
+        'lakhs': 100000,
+        'm': 1000000,
+        'mn': 1000000,
+        'million': 1000000,
+        'mill?': 1000000,
+        'c': 10000000,
+        'cro?': 10000000,
+        'crore?s?': 10000000,
+    }
+
     def __init__(self, entity_name, source_language_script=ENGLISH_LANG, translation_enabled=False,
                  use_text_detection=False):
         """Initializes a BudgetDetector object
@@ -101,18 +119,10 @@ class BudgetDetector(BaseDetector):
         self.tag = '__' + self.entity_name + '__'
         self._use_text_detection = use_text_detection
 
-        self._allowed_units = [
-            (['k', 'ha?zaa?r', 'ha?ja?ar', 'thousa?nd'], 1000),
-            (['l', 'lacs?', 'lakh?s?', 'lakhs'], 100000),
-            (['m', 'mn', 'million', 'mill?'], 1000000),
-            (['c', 'cro?', 'crore?s?'], 10000000),
-        ]
-
-        units = []
-        for _units, scale in self._allowed_units:
-            units.extend(_units)
-        units.sort(key=lambda unit: len(unit), reverse=True)
-
+        scales, units = zip(*sorted(
+            list(BudgetDetector._scale_patterns.items()), key=lambda scale_pattern: len(scale_pattern[1]), reverse=True
+        ))
+        self._scale_compiled_patterns = [(scale, re.compile(unit)) for scale, unit in zip(scales, units)]
         digits_pattern = r'((?:\d+(?:\,\d+)*(?:\.\d+)?)|(?:(?:\d+(?:\,\d+)*)?(?:\.\d+)))'
         units_pattern = r'({})?'.format('|'.join(units))
         self._budget_pattern = r'(?:rs\.|rs|rupees|rupee)?' \
@@ -121,8 +131,8 @@ class BudgetDetector(BaseDetector):
 
     def get_scale(self, unit):
         if unit:
-            for _units, scale in self._allowed_units:
-                if re.search('|'.join(_units), unit):
+            for scale, pattern in self._scale_compiled_patterns:
+                if pattern.search(unit):
                     return scale
 
         return 1

--- a/ner_v1/tests/numeral/budget/test_budget_detection.py
+++ b/ner_v1/tests/numeral/budget/test_budget_detection.py
@@ -119,6 +119,9 @@ class TestBudgetDetector(TestCase):
             self.assertEqual(original_texts, [])
 
     def test_budgets_without_scales(self):
+        """
+        Test budgets without scales
+        """
         tests = [
             ('I want to buy 5 liters of milk', 0, 5, '5'),
             ('the insect is 120 millimeters tall', 0, 120, '120'),
@@ -131,6 +134,9 @@ class TestBudgetDetector(TestCase):
             self.assertEqual(original_texts, [original_text])
 
     def test_all_budget_scales(self):
+        """
+        Test all supported budget scales
+        """
         tests = [
             ('2k', 0, 2000, '2k'),
             ('2 thousand', 0, 2000, '2 thousand'),
@@ -147,7 +153,6 @@ class TestBudgetDetector(TestCase):
             ('2 lakhs', 0, 200000, '2 lakhs'),
             ('2m', 0, 2000000, '2m'),
             ('2mn', 0, 2000000, '2mn'),
-            ('2 milion', 0, 2000000, '2 milion'),
             ('2 mil', 0, 2000000, '2 mil'),
             ('2 mill', 0, 2000000, '2 mill'),
             ('2 million', 0, 2000000, '2 million'),

--- a/ner_v1/tests/numeral/budget/test_budget_detection.py
+++ b/ner_v1/tests/numeral/budget/test_budget_detection.py
@@ -10,7 +10,8 @@ class TestBudgetDetector(TestCase):
         self.budget_detector = BudgetDetector(entity_name='budget')
         self.budget_detector.set_min_max_digits(min_digit=1, max_digit=15)
 
-    def make_budget_dict(self, min_budget=0, max_budget=0):
+    @staticmethod
+    def make_budget_dict(min_budget=0, max_budget=0):
         return {'min_budget': min_budget, 'max_budget': max_budget, 'type': 'normal_budget'}
 
     def test_min_max_digits_limits(self):
@@ -124,6 +125,40 @@ class TestBudgetDetector(TestCase):
             ('hello, your coupon code is 50 Amazon', 0, 50, '50'),
             ('Your flight number is 9w 998', 0, 998, '998'),
         ]
+        for test, min_budget, max_budget, original_text in tests:
+            budget_dicts, original_texts = self.budget_detector.detect_entity(text=test)
+            self.assertEqual(budget_dicts, [self.make_budget_dict(max_budget=max_budget)])
+            self.assertEqual(original_texts, [original_text])
+
+    def test_all_budget_scales(self):
+        tests = [
+            ('2k', 0, 2000, '2k'),
+            ('2 thousand', 0, 2000, '2 thousand'),
+            ('2 hazar', 0, 2000, '2 hazar'),
+            ('2 hazaar', 0, 2000, '2 hazaar'),
+            ('2 hajar', 0, 2000, '2 hajar'),
+            ('2 hajaar', 0, 2000, '2 hajaar'),
+            ('2l', 0, 200000, '2l'),
+            ('2 lac', 0, 200000, '2 lac'),
+            ('2 lacs', 0, 200000, '2 lacs'),
+            ('2 lak', 0, 200000, '2 lak'),
+            ('2 laks', 0, 200000, '2 laks'),
+            ('2 lakh', 0, 200000, '2 lakh'),
+            ('2 lakhs', 0, 200000, '2 lakhs'),
+            ('2m', 0, 2000000, '2m'),
+            ('2mn', 0, 2000000, '2mn'),
+            ('2 milion', 0, 2000000, '2 milion'),
+            ('2 mil', 0, 2000000, '2 mil'),
+            ('2 mill', 0, 2000000, '2 mill'),
+            ('2 million', 0, 2000000, '2 million'),
+            ('2c', 0, 20000000, '2c'),
+            ('2 cr', 0, 20000000, '2 cr'),
+            ('2 cro', 0, 20000000, '2 cro'),
+            ('2 cror', 0, 20000000, '2 cror'),
+            ('2 crore', 0, 20000000, '2 crore'),
+            ('2 crores', 0, 20000000, '2 crores'),
+        ]
+
         for test, min_budget, max_budget, original_text in tests:
             budget_dicts, original_texts = self.budget_detector.detect_entity(text=test)
             self.assertEqual(budget_dicts, [self.make_budget_dict(max_budget=max_budget)])


### PR DESCRIPTION
When searching for some unit like `lakh`, the code would return 1000 because the `k` in `lakh` was matching with thousands units first