### PR TITLE
Fix issue in single char scale for number detection

### DIFF
--- a/ner_v2/detectors/numeral/utils.py
+++ b/ner_v2/detectors/numeral/utils.py
@@ -24,6 +24,9 @@ def get_number_from_number_word(text, number_word_dict):
     detected_number_list = []
     detected_original_text_list = []
 
+    # exclude single char scales word from word number map dict
+    number_word_dict = {word: number_map for word, number_map in number_word_dict.items()
+                        if len(word) > 1 and number_map.unit == 0}
     text = text.strip()
     if not text:
         return detected_number_list, detected_original_text_list
@@ -72,7 +75,8 @@ def get_number_from_number_word(text, number_word_dict):
                 result = current = 0
                 result_text, current_text = '', ''
 
-            # handle where only scale is mentioned without unit, for ex - thousand(for 1000), hundred(for 100)
+            # handle where only scale is mentioned without unit, for ex - thousand(for 1000), hundred(for 100) and
+            # exclude cases like 'm' (for million) or 'k' (thousand)
             current = 1 if (scale > 0 and current == 0 and increment == 0) else current
             current = current * scale + increment
             current_text += part

--- a/ner_v2/detectors/numeral/utils.py
+++ b/ner_v2/detectors/numeral/utils.py
@@ -11,8 +11,12 @@ def get_number_from_number_word(text, number_word_dict):
         detected_number_list (list): list of numeric value detected from text
         detected_original_text_list (list): list of original text for numeric value detected
     Examples:
-        [In]  >>  number_word_dict = {'one': (1, 1), 'two': (1, 2), 'three': (1, 3), 'thousand': (1000, 0),
-                                      'four': (1, 4), 'hundred': (100, 0)
+        [In]  >>  number_word_dict = {'one': NumberVariant(scale=1, increment=1),
+                                      'two': NumberVariant(scale=1, increment=2),
+                                      'three': NumberVariant(scale=1, increment=3),
+                                      'thousand': NumberVariant(scale=1000, increment=0),
+                                      'four': NumberVariant(scale=1, increment=4),
+                                      'hundred': NumberVariant(scale=100, increment=0)
                                       }
         [In]  >>  _get_number_from_numerals('one thousand two',  number_word_dict)
         [Out] >> (['1002'], ['one thousand two'])
@@ -26,7 +30,7 @@ def get_number_from_number_word(text, number_word_dict):
 
     # exclude single char scales word from word number map dict
     number_word_dict = {word: number_map for word, number_map in number_word_dict.items()
-                        if len(word) > 1 and number_map.unit == 0}
+                        if len(word) > 1 and number_map.increment == 0}
     text = text.strip()
     if not text:
         return detected_number_list, detected_original_text_list

--- a/ner_v2/detectors/numeral/utils.py
+++ b/ner_v2/detectors/numeral/utils.py
@@ -79,8 +79,7 @@ def get_number_from_number_word(text, number_word_dict):
                 result = current = 0
                 result_text, current_text = '', ''
 
-            # handle where only scale is mentioned without unit, for ex - thousand(for 1000), hundred(for 100) and
-            # exclude cases like 'm' (for million) or 'k' (thousand)
+            # handle where only scale is mentioned without unit, for ex - thousand(for 1000), hundred(for 100)
             current = 1 if (scale > 0 and current == 0 and increment == 0) else current
             current = current * scale + increment
             current_text += part

--- a/ner_v2/detectors/numeral/utils.py
+++ b/ner_v2/detectors/numeral/utils.py
@@ -30,7 +30,7 @@ def get_number_from_number_word(text, number_word_dict):
 
     # exclude single char scales word from word number map dict
     number_word_dict = {word: number_map for word, number_map in number_word_dict.items()
-                        if len(word) > 1 and number_map.increment == 0}
+                        if (len(word) > 1 and number_map.scale == 0) or number_map.scale == 1}
     text = text.strip()
     if not text:
         return detected_number_list, detected_original_text_list

--- a/ner_v2/detectors/numeral/utils.py
+++ b/ner_v2/detectors/numeral/utils.py
@@ -30,7 +30,7 @@ def get_number_from_number_word(text, number_word_dict):
 
     # exclude single char scales word from word number map dict
     number_word_dict = {word: number_map for word, number_map in number_word_dict.items()
-                        if (len(word) > 1 and number_map.scale == 0) or number_map.scale == 1}
+                        if (len(word) > 1 and number_map.increment == 0) or number_map.scale == 1}
     text = text.strip()
     if not text:
         return detected_number_list, detected_original_text_list


### PR DESCRIPTION
**Issue** - In number detection single scale char like `m` is being detected as 1 million
**Solution** - not considering scale word with len = 1 while converting number words to number