### PR TITLE
add new version of django upgrade for security

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy==1.10.4
 elasticsearch==5.5.0
 requests==2.20.0
 requests-aws4auth==0.9
-Django==1.11.26
+Django==1.11.27
 django-dotenv==1.4.2
 weighted-levenshtein==0.1
 regex==2018.7.11


### PR DESCRIPTION
add new version of django upgrade for security - 1.11.26 to 1.11.27
(affects) application packages 
ADO-3054