### PR TITLE
Return type fix in TextDetector.detect_entity

### DIFF
--- a/ner_v1/detectors/numeral/budget/budget_detection.py
+++ b/ner_v1/detectors/numeral/budget/budget_detection.py
@@ -407,7 +407,7 @@ class BudgetDetector(BaseDetector):
 
         text_detection_object = TextDetector(entity_name=self.entity_name)
 
-        budget_text_list, original_text_list = text_detection_object.detect_entity(self.text)
+        budget_text_list, original_text_list = text_detection_object.detect_entity(self.text, return_str=True)
         # FIXME: Broken/Ineffective code.
         self.tagged_text = text_detection_object.tagged_text
         self.processed_text = text_detection_object.processed_text

--- a/ner_v1/detectors/numeral/size/shopping_size_detection.py
+++ b/ner_v1/detectors/numeral/size/shopping_size_detection.py
@@ -133,7 +133,7 @@ class ShoppingSizeDetector(BaseDetector):
         if original_list is None:
             original_list = []
 
-        size_list, original_list = self.text_detection_object.detect_entity(self.text)
+        size_list, original_list = self.text_detection_object.detect_entity(self.text, return_str=True)
         self.tagged_text = self.text_detection_object.tagged_text
         self.processed_text = self.text_detection_object.processed_text
         return size_list, original_list

--- a/ner_v1/detectors/textual/city/city_detection.py
+++ b/ner_v1/detectors/textual/city/city_detection.py
@@ -394,7 +394,7 @@ class CityDetector(object):
 
                 (['Mumbai'], ['bombay'])
         """
-        city_list, original_list = self.text_detection_object.detect_entity(text)
+        city_list, original_list = self.text_detection_object.detect_entity(text, return_str=True)
         return city_list, original_list
 
     def _update_processed_text(self, city_dict_list):

--- a/ner_v1/detectors/textual/text/text_detection.py
+++ b/ner_v1/detectors/textual/text/text_detection.py
@@ -359,7 +359,7 @@ class TextDetector(BaseDetector):
 
         return combined_entity_values, combined_original_texts
 
-    def detect_entity(self, text, predetected_values=None, **kwargs):
+    def detect_entity(self, text, predetected_values=None, return_str=False, **kwargs):
         """
         Detects all textual entities in text that are similar to variants of 'entity_name' stored in the datastore and
         returns two lists of detected text entities and their corresponding original substrings in text respectively.
@@ -369,6 +369,7 @@ class TextDetector(BaseDetector):
         Args:
             text (str): string to extract textual entities from
             predetected_values (list of str): prior detection results
+            return_str(bool): To call combine results or not.
             **kwargs: it can be used to send specific arguments in future. for example, fuzziness, previous context.
         Returns:
             tuple:
@@ -405,8 +406,9 @@ class TextDetector(BaseDetector):
             self.processed_text = self.__processed_texts[0]
             values, texts = text_entity_values[0], original_texts[0]
 
-        values, texts = self.combine_results(values=values, original_texts=texts,
-                                             predetected_values=predetected_values)
+        if not return_str:
+            values, texts = self.combine_results(values=values, original_texts=texts,
+                                                 predetected_values=predetected_values)
 
         return values, texts
 

--- a/ner_v1/detectors/textual/text/text_detection.py
+++ b/ner_v1/detectors/textual/text/text_detection.py
@@ -10,6 +10,7 @@ from datastore import DataStore
 from lib.nlp.const import TOKENIZER, whitespace_tokenizer
 from lib.nlp.levenshtein_distance import edit_distance
 from ner_v1.detectors.base_detector import BaseDetector
+from ner_constants import ENTITY_VALUE_DICT_KEY
 
 try:
     import regex as re
@@ -406,9 +407,10 @@ class TextDetector(BaseDetector):
             self.processed_text = self.__processed_texts[0]
             values, texts = text_entity_values[0], original_texts[0]
 
-        if not return_str:
-            values, texts = self.combine_results(values=values, original_texts=texts,
-                                                 predetected_values=predetected_values)
+        values, texts = self.combine_results(values=values, original_texts=texts,
+                                             predetected_values=predetected_values)
+        if return_str:
+            values = [value_dict[ENTITY_VALUE_DICT_KEY] for value_dict in values]
 
         return values, texts
 


### PR DESCRIPTION
- Some entity functions expect entity value with type `str`.
- TextDetector.detect_entity returns entity value as `dict`
- Return `str` for certain entity functions