### PR TITLE
3rd set of python 2 and 3 compatible changes

### DIFF
--- a/ner_v1/detectors/textual/city/city_detection.py
+++ b/ner_v1/detectors/textual/city/city_detection.py
@@ -139,7 +139,8 @@ class CityDetector(object):
             Whereas for arrival city the key "to" will be set to True.
         """
         city_dict_list = []
-        patterns = re.findall(u'\\s(([A-Za-z\u0900-\u097F]+)\\s+(\-|to|2|se|से|and)\\s+([A-Za-z\u0900-\u097F\\s]+))\.?',
+        patterns = re.findall(u'\\s(([A-Za-z\u0900-\u097F]+)\\s'
+                              '+(\\-|to|2|se|से|and)\\s+([A-Za-z\u0900-\u097F\\s]+))\\.?',
                               self.processed_text.lower(), re.UNICODE)
         for pattern in patterns:
             city_dict_list.extend(
@@ -170,7 +171,7 @@ class CityDetector(object):
         city_dict_list = []
         patterns = re.findall(u'\\s((?:from|frm|departing|depart|leaving|leave)\\s+([A-Za-z\u0900-\u097F]+)'
                               u'\\s+(?:and|to|se|से|2|for|fr|arriving|arrive|reaching|reach|rch)'
-                              u'\\s+([A-Za-z\u0900-\u097F]+))\.?',
+                              u'\\s+([A-Za-z\u0900-\u097F]+))\\.?',
                               self.processed_text.lower(), re.UNICODE)
 
         for pattern in patterns:
@@ -203,7 +204,7 @@ class CityDetector(object):
         city_dict_list = []
         patterns = re.findall(u'\\s((?:and|to|2|for|fr|arriving|arrive|reaching|reach|rch)'
                               u'\\s+([A-Za-z\u0900-\u097F]+)\\s+(?:from|frm|departing|depart|leaving|leave)'
-                              u'\\s+([A-Za-z\u0900-\u097F]+))\.?',
+                              u'\\s+([A-Za-z\u0900-\u097F]+))\\.?',
                               self.processed_text.lower(), re.UNICODE)
 
         for pattern in patterns:
@@ -232,8 +233,9 @@ class CityDetector(object):
 
         """
         city_dict_list = []
-        patterns = re.findall(u'\\s((from|frm|departing|depart|leaving|leave|origin city\:|departure city\:|going to)'
-                              u'\\s+([A-Za-z\u0900-\u097F]+))\.?\\s',
+        patterns = re.findall(u'\\s((from|frm|departing|depart|leaving|leave|origin '
+                              'city\\:|departure city\\:|going to)'
+                              u'\\s+([A-Za-z\u0900-\u097F]+))\\.?\\s',
                               self.processed_text.lower(), re.UNICODE)
 
         for pattern in patterns:
@@ -259,8 +261,8 @@ class CityDetector(object):
         """
         city_dict_list = []
         patterns_1 = re.findall(u'\\s((to|2|for|fr|arriving|arrive|reaching|'
-                                u'reach|rch|destination city\:|arrival city\:)'
-                                u'\\s+([A-Za-z\u0900-\u097F]+))\.?\\s',
+                                u'reach|rch|destination city\\:|arrival city\\:)'
+                                u'\\s+([A-Za-z\u0900-\u097F]+))\\.?\\s',
                                 self.processed_text.lower(), re.UNICODE)
         patterns_2 = re.findall(u'([A-Za-z\u0900-\u097F]+)\\s+(jana|jaana|jau|ghum|ghoom|जाना|जाऊं|जाऊँ|घूम)',
                                 self.processed_text.lower(),
@@ -312,7 +314,7 @@ class CityDetector(object):
             elif arrival_regexp.search(self.bot_message) is not None:
                 arrival_city_flag = True
 
-        patterns = re.findall(u'\\s((.+))\.?', self.processed_text.lower(), re.UNICODE)
+        patterns = re.findall(u'\\s((.+))\\.?', self.processed_text.lower(), re.UNICODE)
 
         for pattern in patterns:
             pattern = list(pattern)

--- a/ner_v1/detectors/textual/city/city_detection.py
+++ b/ner_v1/detectors/textual/city/city_detection.py
@@ -139,7 +139,7 @@ class CityDetector(object):
             Whereas for arrival city the key "to" will be set to True.
         """
         city_dict_list = []
-        patterns = re.findall(ur'\s(([A-Za-z\u0900-\u097F]+)\s+(\-|to|2|se|से|and)\s+([A-Za-z\u0900-\u097F\s]+))\.?',
+        patterns = re.findall(u'\\s(([A-Za-z\u0900-\u097F]+)\\s+(\-|to|2|se|से|and)\\s+([A-Za-z\u0900-\u097F\\s]+))\.?',
                               self.processed_text.lower(), re.UNICODE)
         for pattern in patterns:
             city_dict_list.extend(
@@ -168,9 +168,9 @@ class CityDetector(object):
             Whereas for arrival city the key "to" will be set to True.
         """
         city_dict_list = []
-        patterns = re.findall(ur'\s((?:from|frm|departing|depart|leaving|leave)\s+([A-Za-z\u0900-\u097F]+)'
-                              ur'\s+(?:and|to|se|से|2|for|fr|arriving|arrive|reaching|reach|rch)'
-                              ur'\s+([A-Za-z\u0900-\u097F]+))\.?',
+        patterns = re.findall(u'\\s((?:from|frm|departing|depart|leaving|leave)\\s+([A-Za-z\u0900-\u097F]+)'
+                              u'\\s+(?:and|to|se|से|2|for|fr|arriving|arrive|reaching|reach|rch)'
+                              u'\\s+([A-Za-z\u0900-\u097F]+))\.?',
                               self.processed_text.lower(), re.UNICODE)
 
         for pattern in patterns:
@@ -201,9 +201,9 @@ class CityDetector(object):
 
         """
         city_dict_list = []
-        patterns = re.findall(ur'\s((?:and|to|2|for|fr|arriving|arrive|reaching|reach|rch)'
-                              ur'\s+([A-Za-z\u0900-\u097F]+)\s+(?:from|frm|departing|depart|leaving|leave)'
-                              ur'\s+([A-Za-z\u0900-\u097F]+))\.?',
+        patterns = re.findall(u'\\s((?:and|to|2|for|fr|arriving|arrive|reaching|reach|rch)'
+                              u'\\s+([A-Za-z\u0900-\u097F]+)\\s+(?:from|frm|departing|depart|leaving|leave)'
+                              u'\\s+([A-Za-z\u0900-\u097F]+))\.?',
                               self.processed_text.lower(), re.UNICODE)
 
         for pattern in patterns:
@@ -232,8 +232,8 @@ class CityDetector(object):
 
         """
         city_dict_list = []
-        patterns = re.findall(ur'\s((from|frm|departing|depart|leaving|leave|origin city\:|departure city\:|going to)'
-                              ur'\s+([A-Za-z\u0900-\u097F]+))\.?\s',
+        patterns = re.findall(u'\\s((from|frm|departing|depart|leaving|leave|origin city\:|departure city\:|going to)'
+                              u'\\s+([A-Za-z\u0900-\u097F]+))\.?\\s',
                               self.processed_text.lower(), re.UNICODE)
 
         for pattern in patterns:
@@ -258,11 +258,11 @@ class CityDetector(object):
 
         """
         city_dict_list = []
-        patterns_1 = re.findall(ur'\s((to|2|for|fr|arriving|arrive|reaching|'
-                                ur'reach|rch|destination city\:|arrival city\:)'
-                                ur'\s+([A-Za-z\u0900-\u097F]+))\.?\s',
+        patterns_1 = re.findall(u'\\s((to|2|for|fr|arriving|arrive|reaching|'
+                                u'reach|rch|destination city\:|arrival city\:)'
+                                u'\\s+([A-Za-z\u0900-\u097F]+))\.?\\s',
                                 self.processed_text.lower(), re.UNICODE)
-        patterns_2 = re.findall(ur'([A-Za-z\u0900-\u097F]+)\s+(jana|jaana|jau|ghum|ghoom|जाना|जाऊं|जाऊँ|घूम)',
+        patterns_2 = re.findall(u'([A-Za-z\u0900-\u097F]+)\\s+(jana|jaana|jau|ghum|ghoom|जाना|जाऊं|जाऊँ|घूम)',
                                 self.processed_text.lower(),
                                 re.UNICODE)
         for pattern in patterns_1:
@@ -300,19 +300,19 @@ class CityDetector(object):
         arrival_city_flag = False
         if self.bot_message:
             hinglish_departure = u'कहां से'
-            departure_regexp = re.compile(ur'departure city|origin city|origin|'
-                                          ur'traveling from|leaving from|flying from|travelling from|'
+            departure_regexp = re.compile(u'departure city|origin city|origin|'
+                                          u'traveling from|leaving from|flying from|travelling from|'
                                           + hinglish_departure)
             hinglish_arrival = u'कहां जाना|\u0916\u093c\u0924\u092e|\u0959\u0924\u092e'  # unicode for ख़तम
-            arrival_regexp = re.compile(ur'traveling to|travelling to|arrival city|'
-                                        ur'arrival|destination city|destination|leaving to|flying to|'
+            arrival_regexp = re.compile(u'traveling to|travelling to|arrival city|'
+                                        u'arrival|destination city|destination|leaving to|flying to|'
                                         + hinglish_arrival)
             if departure_regexp.search(self.bot_message) is not None:
                 departure_city_flag = True
             elif arrival_regexp.search(self.bot_message) is not None:
                 arrival_city_flag = True
 
-        patterns = re.findall(ur'\s((.+))\.?', self.processed_text.lower(), re.UNICODE)
+        patterns = re.findall(u'\\s((.+))\.?', self.processed_text.lower(), re.UNICODE)
 
         for pattern in patterns:
             pattern = list(pattern)

--- a/ner_v1/detectors/textual/name/name_detection.py
+++ b/ner_v1/detectors/textual/name/name_detection.py
@@ -233,7 +233,7 @@ class NameDetector(object):
 
         text = self.remove_emojis(text=self.text)
         text_before_hindi_regex_operations = text
-        regex = re.compile(u'[^\u0900-\u097F\s]+', re.U)
+        regex = re.compile(u'[^\u0900-\u097F\\s]+', re.U)
         text = regex.sub(string=text, repl='')
 
         regex_detection_result = self.get_hindi_names_from_regex(text=text)
@@ -244,9 +244,9 @@ class NameDetector(object):
             entity_value, original_text = self.get_hindi_names_without_regex(text=text)
         # Further check for name, if it might have been written in latin script.
         if not entity_value:
-            english_present_regex = re.compile(u'[a-zA-Z\s]+', re.U)
+            english_present_regex = re.compile(u'[a-zA-Z\\s]+', re.U)
             if english_present_regex.search(text_before_hindi_regex_operations):
-                remove_everything_except_english = re.compile(u'[^a-zA-Z\s]+', re.U)
+                remove_everything_except_english = re.compile(u'[^a-zA-Z\\s]+', re.U)
                 text_only_english = remove_everything_except_english.sub(
                     string=text_before_hindi_regex_operations, repl='')
                 entity_value, original_text = self.detect_english_name(text=text_only_english.strip())
@@ -467,11 +467,11 @@ class NameDetector(object):
             >>[u'प्रतिक श्रीदत्त जयराओ']
 
         """
-        regex_list = [u"(?:मुझे|हमें|मुझको|हमको|हमे)\s+(?:लोग)\s+([\u0900-\u097F\s]+)"
-                      u"\s+(?:नाम\sसे)\s+(?:कहते|बुलाते|बुलाओ)",
-                      u"(?:नाम|मैं|हम|मै)\s+([\u0900-\u097F\s]+)",
-                      u"(?:मुझे|हमें|मुझको|हमको|हमे)\s+([\u0900-\u097F\s]+)(?:कहते|बुलाते|बुलाओ)",
-                      u"\s*([\u0900-\u097F\s]+)(?:मुझे|मैं|मै)(?:कहते|बुलाते|बुलाओ)?"
+        regex_list = [u"(?:मुझे|हमें|मुझको|हमको|हमे)\\s+(?:लोग)\\s+([\u0900-\u097F\\s]+)"
+                      u"\\s+(?:नाम\\sसे)\\s+(?:कहते|बुलाते|बुलाओ)",
+                      u"(?:नाम|मैं|हम|मै)\\s+([\u0900-\u097F\\s]+)",
+                      u"(?:मुझे|हमें|मुझको|हमको|हमे)\\s+([\u0900-\u097F\\s]+)(?:कहते|बुलाते|बुलाओ)",
+                      u"\\s*([\u0900-\u097F\\s]+)(?:मुझे|मैं|मै)(?:कहते|बुलाते|बुलाओ)?"
                       ]
 
         for regex in regex_list:

--- a/ner_v1/detectors/textual/name/name_detection.py
+++ b/ner_v1/detectors/textual/name/name_detection.py
@@ -233,7 +233,7 @@ class NameDetector(object):
 
         text = self.remove_emojis(text=self.text)
         text_before_hindi_regex_operations = text
-        regex = re.compile(ur'[^\u0900-\u097F\s]+', re.U)
+        regex = re.compile(u'[^\u0900-\u097F\s]+', re.U)
         text = regex.sub(string=text, repl='')
 
         regex_detection_result = self.get_hindi_names_from_regex(text=text)
@@ -244,9 +244,9 @@ class NameDetector(object):
             entity_value, original_text = self.get_hindi_names_without_regex(text=text)
         # Further check for name, if it might have been written in latin script.
         if not entity_value:
-            english_present_regex = re.compile(ur'[a-zA-Z\s]+', re.U)
+            english_present_regex = re.compile(u'[a-zA-Z\s]+', re.U)
             if english_present_regex.search(text_before_hindi_regex_operations):
-                remove_everything_except_english = re.compile(ur'[^a-zA-Z\s]+', re.U)
+                remove_everything_except_english = re.compile(u'[^a-zA-Z\s]+', re.U)
                 text_only_english = remove_everything_except_english.sub(
                     string=text_before_hindi_regex_operations, repl='')
                 entity_value, original_text = self.detect_english_name(text=text_only_english.strip())
@@ -467,11 +467,11 @@ class NameDetector(object):
             >>[u'प्रतिक श्रीदत्त जयराओ']
 
         """
-        regex_list = [ur"(?:मुझे|हमें|मुझको|हमको|हमे)\s+(?:लोग)\s+([\u0900-\u097F\s]+)"
-                      ur"\s+(?:नाम\sसे)\s+(?:कहते|बुलाते|बुलाओ)",
-                      ur"(?:नाम|मैं|हम|मै)\s+([\u0900-\u097F\s]+)",
-                      ur"(?:मुझे|हमें|मुझको|हमको|हमे)\s+([\u0900-\u097F\s]+)(?:कहते|बुलाते|बुलाओ)",
-                      ur"\s*([\u0900-\u097F\s]+)(?:मुझे|मैं|मै)(?:कहते|बुलाते|बुलाओ)?"
+        regex_list = [u"(?:मुझे|हमें|मुझको|हमको|हमे)\s+(?:लोग)\s+([\u0900-\u097F\s]+)"
+                      u"\s+(?:नाम\sसे)\s+(?:कहते|बुलाते|बुलाओ)",
+                      u"(?:नाम|मैं|हम|मै)\s+([\u0900-\u097F\s]+)",
+                      u"(?:मुझे|हमें|मुझको|हमको|हमे)\s+([\u0900-\u097F\s]+)(?:कहते|बुलाते|बुलाओ)",
+                      u"\s*([\u0900-\u097F\s]+)(?:मुझे|मैं|मै)(?:कहते|बुलाते|बुलाओ)?"
                       ]
 
         for regex in regex_list:
@@ -523,7 +523,7 @@ class NameDetector(object):
         Returns:
             text (str): text with emojis replaced with ''
         """
-        emoji_pattern = re.compile(ur'[{0}]+'.format(''.join(list(EMOJI_RANGES.values()))), re.UNICODE)
+        emoji_pattern = re.compile(u'[{0}]+'.format(''.join(list(EMOJI_RANGES.values()))), re.UNICODE)
         text = emoji_pattern.sub(repl='', string=text)
         return text
 

--- a/ner_v2/detectors/numeral/number_range/en/number_range_detection.py
+++ b/ner_v2/detectors/numeral/number_range/en/number_range_detection.py
@@ -42,8 +42,8 @@ class NumberRangeDetector(BaseNumberRangeDetector):
         """
         number_range_list = number_range_list or []
         original_list = original_list or []
-        between_range_pattern = re.compile(ur'(between\s+({number}\d+)(?:\s+and|-)'
-                                           ur'\s+({number}\d+))'.format(number=NUMBER_REPLACE_TEXT), re.UNICODE)
+        between_range_pattern = re.compile(r'(between\s+({number}\d+)(?:\s+and|-)'
+                                           r'\s+({number}\d+))'.format(number=NUMBER_REPLACE_TEXT), re.UNICODE)
         number_range_matches = between_range_pattern.findall(self.processed_text)
         for match in number_range_matches:
             number_range, original_text = self._get_number_range(min_part_match=match[1], max_part_match=match[2],

--- a/ner_v2/detectors/numeral/number_range/en/number_range_detection.py
+++ b/ner_v2/detectors/numeral/number_range/en/number_range_detection.py
@@ -42,8 +42,8 @@ class NumberRangeDetector(BaseNumberRangeDetector):
         """
         number_range_list = number_range_list or []
         original_list = original_list or []
-        between_range_pattern = re.compile(r'(between\s+({number}\d+)(?:\s+and|-)'
-                                           r'\s+({number}\d+))'.format(number=NUMBER_REPLACE_TEXT), re.UNICODE)
+        between_range_pattern = re.compile(u'(between\\s+({number}\\d+)(?:\\s+and|-)'
+                                           u'\\s+({number}\\d+))'.format(number=NUMBER_REPLACE_TEXT), re.UNICODE)
         number_range_matches = between_range_pattern.findall(self.processed_text)
         for match in number_range_matches:
             number_range, original_text = self._get_number_range(min_part_match=match[1], max_part_match=match[2],

--- a/ner_v2/detectors/numeral/number_range/standard_number_range_detector.py
+++ b/ner_v2/detectors/numeral/number_range/standard_number_range_detector.py
@@ -423,7 +423,7 @@ class BaseNumberRangeDetector(object):
                                        created from entity_name
         """
         for detected_text in original_number_list:
-            _pattern = re.compile(u'\b%s\b' % re.escape(detected_text), flags=_re_flags)
+            _pattern = re.compile(u'\\b%s\\b' % re.escape(detected_text), flags=_re_flags)
             self.tagged_text = _pattern.sub(self.tag, self.tagged_text)
 
 

--- a/ner_v2/detectors/numeral/number_range/standard_number_range_detector.py
+++ b/ner_v2/detectors/numeral/number_range/standard_number_range_detector.py
@@ -194,7 +194,7 @@ class BaseNumberRangeDetector(object):
     def _detect_absolute_number(self, number_list, original_list):
         number_list = number_list or []
         original_list = original_list or []
-        abs_number_pattern = re.compile(u'({number}\d+)'.format(number=numeral_constant.NUMBER_REPLACE_TEXT),
+        abs_number_pattern = re.compile(u'({number}\\d+)'.format(number=numeral_constant.NUMBER_REPLACE_TEXT),
                                         re.UNICODE)
         abs_number_matches = abs_number_pattern.findall(self.processed_text)
         for match in abs_number_matches:
@@ -282,7 +282,7 @@ class BaseNumberRangeDetector(object):
 
         if self.min_range_prefix_variants:
             min_prefix_choices = '|'.join(self.min_range_prefix_variants)
-            min_range_start_pattern = re.compile(u'((?:{min_prefix_choices})\s+({number}\d+))'.format(
+            min_range_start_pattern = re.compile(u'((?:{min_prefix_choices})\\s+({number}\\d+))'.format(
                 number=numeral_constant.NUMBER_REPLACE_TEXT, min_prefix_choices=min_prefix_choices), re.UNICODE)
             number_range_matches = min_range_start_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -310,7 +310,7 @@ class BaseNumberRangeDetector(object):
 
         if self.min_range_suffix_variants:
             min_suffix_choices = '|'.join(self.min_range_suffix_variants)
-            min_range_end_pattern = re.compile(u'(({number}\d+)\s+(?:{min_suffix_choices}))'.format(
+            min_range_end_pattern = re.compile(u'(({number}\\d+)\\s+(?:{min_suffix_choices}))'.format(
                 number=numeral_constant.NUMBER_REPLACE_TEXT, min_suffix_choices=min_suffix_choices), re.UNICODE)
             number_range_matches = min_range_end_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -340,7 +340,7 @@ class BaseNumberRangeDetector(object):
 
         if self.max_range_prefix_variants:
             max_prefix_choices = '|'.join(self.max_range_prefix_variants)
-            max_range_start_pattern = re.compile(u'((?:{max_prefix_choices})\s+({number}\d+))'.format(
+            max_range_start_pattern = re.compile(u'((?:{max_prefix_choices})\\s+({number}\\d+))'.format(
                 number=numeral_constant.NUMBER_REPLACE_TEXT, max_prefix_choices=max_prefix_choices), re.UNICODE)
             number_range_matches = max_range_start_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -369,7 +369,7 @@ class BaseNumberRangeDetector(object):
 
         if self.max_range_suffix_variants:
             max_suffix_choices = '|'.join(self.max_range_suffix_variants)
-            max_range_end_pattern = re.compile(u'(({number}\d+)\s+(?:{max_suffix_choices}))'.format(
+            max_range_end_pattern = re.compile(u'(({number}\\d+)\\s+(?:{max_suffix_choices}))'.format(
                 number=numeral_constant.NUMBER_REPLACE_TEXT, max_suffix_choices=max_suffix_choices), re.UNICODE)
             number_range_matches = max_range_end_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -399,8 +399,8 @@ class BaseNumberRangeDetector(object):
 
         if self.min_max_range_variants:
             min_max_choices = '|'.join(self.min_max_range_variants)
-            min_max_range_pattern = re.compile(u'(({number}\d+)\s*(?:{min_max_choices})\s*'
-                                               u'({number}\d+))'.format(number=numeral_constant.NUMBER_REPLACE_TEXT,
+            min_max_range_pattern = re.compile(u'(({number}\\d+)\\s*(?:{min_max_choices})\\s*'
+                                               u'({number}\\d+))'.format(number=numeral_constant.NUMBER_REPLACE_TEXT,
                                                                          min_max_choices=min_max_choices), re.UNICODE)
             number_range_matches = min_max_range_pattern.findall(self.processed_text)
             for match in number_range_matches:

--- a/ner_v2/detectors/numeral/number_range/standard_number_range_detector.py
+++ b/ner_v2/detectors/numeral/number_range/standard_number_range_detector.py
@@ -18,7 +18,7 @@ except ImportError:
     _re_flags = re.UNICODE
 
 NumberRangeVariant = collections.namedtuple('NumberRangeVariant', ['position', 'range_type'])
-ValueTextPair = collections.namedtuple('ValueTextPair', ['entity_value', 'original_text'])
+ValueTextPair = collections.namedtuple('ValueTextPaiu', ['entity_value', 'original_text'])
 
 
 class BaseNumberRangeDetector(object):
@@ -194,7 +194,7 @@ class BaseNumberRangeDetector(object):
     def _detect_absolute_number(self, number_list, original_list):
         number_list = number_list or []
         original_list = original_list or []
-        abs_number_pattern = re.compile(ur'({number}\d+)'.format(number=numeral_constant.NUMBER_REPLACE_TEXT),
+        abs_number_pattern = re.compile(u'({number}\d+)'.format(number=numeral_constant.NUMBER_REPLACE_TEXT),
                                         re.UNICODE)
         abs_number_matches = abs_number_pattern.findall(self.processed_text)
         for match in abs_number_matches:
@@ -282,7 +282,7 @@ class BaseNumberRangeDetector(object):
 
         if self.min_range_prefix_variants:
             min_prefix_choices = '|'.join(self.min_range_prefix_variants)
-            min_range_start_pattern = re.compile(ur'((?:{min_prefix_choices})\s+({number}\d+))'.format(
+            min_range_start_pattern = re.compile(u'((?:{min_prefix_choices})\s+({number}\d+))'.format(
                 number=numeral_constant.NUMBER_REPLACE_TEXT, min_prefix_choices=min_prefix_choices), re.UNICODE)
             number_range_matches = min_range_start_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -310,7 +310,7 @@ class BaseNumberRangeDetector(object):
 
         if self.min_range_suffix_variants:
             min_suffix_choices = '|'.join(self.min_range_suffix_variants)
-            min_range_end_pattern = re.compile(ur'(({number}\d+)\s+(?:{min_suffix_choices}))'.format(
+            min_range_end_pattern = re.compile(u'(({number}\d+)\s+(?:{min_suffix_choices}))'.format(
                 number=numeral_constant.NUMBER_REPLACE_TEXT, min_suffix_choices=min_suffix_choices), re.UNICODE)
             number_range_matches = min_range_end_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -340,7 +340,7 @@ class BaseNumberRangeDetector(object):
 
         if self.max_range_prefix_variants:
             max_prefix_choices = '|'.join(self.max_range_prefix_variants)
-            max_range_start_pattern = re.compile(ur'((?:{max_prefix_choices})\s+({number}\d+))'.format(
+            max_range_start_pattern = re.compile(u'((?:{max_prefix_choices})\s+({number}\d+))'.format(
                 number=numeral_constant.NUMBER_REPLACE_TEXT, max_prefix_choices=max_prefix_choices), re.UNICODE)
             number_range_matches = max_range_start_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -369,7 +369,7 @@ class BaseNumberRangeDetector(object):
 
         if self.max_range_suffix_variants:
             max_suffix_choices = '|'.join(self.max_range_suffix_variants)
-            max_range_end_pattern = re.compile(ur'(({number}\d+)\s+(?:{max_suffix_choices}))'.format(
+            max_range_end_pattern = re.compile(u'(({number}\d+)\s+(?:{max_suffix_choices}))'.format(
                 number=numeral_constant.NUMBER_REPLACE_TEXT, max_suffix_choices=max_suffix_choices), re.UNICODE)
             number_range_matches = max_range_end_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -399,8 +399,8 @@ class BaseNumberRangeDetector(object):
 
         if self.min_max_range_variants:
             min_max_choices = '|'.join(self.min_max_range_variants)
-            min_max_range_pattern = re.compile(ur'(({number}\d+)\s*(?:{min_max_choices})\s*'
-                                               ur'({number}\d+))'.format(number=numeral_constant.NUMBER_REPLACE_TEXT,
+            min_max_range_pattern = re.compile(u'(({number}\d+)\s*(?:{min_max_choices})\s*'
+                                               u'({number}\d+))'.format(number=numeral_constant.NUMBER_REPLACE_TEXT,
                                                                          min_max_choices=min_max_choices), re.UNICODE)
             number_range_matches = min_max_range_pattern.findall(self.processed_text)
             for match in number_range_matches:
@@ -423,7 +423,7 @@ class BaseNumberRangeDetector(object):
                                        created from entity_name
         """
         for detected_text in original_number_list:
-            _pattern = re.compile(r'\b%s\b' % re.escape(detected_text), flags=_re_flags)
+            _pattern = re.compile(u'\b%s\b' % re.escape(detected_text), flags=_re_flags)
             self.tagged_text = _pattern.sub(self.tag, self.tagged_text)
 
 

--- a/ner_v2/detectors/numeral/number_range/standard_number_range_detector.py
+++ b/ner_v2/detectors/numeral/number_range/standard_number_range_detector.py
@@ -18,7 +18,7 @@ except ImportError:
     _re_flags = re.UNICODE
 
 NumberRangeVariant = collections.namedtuple('NumberRangeVariant', ['position', 'range_type'])
-ValueTextPair = collections.namedtuple('ValueTextPaiu', ['entity_value', 'original_text'])
+ValueTextPair = collections.namedtuple('ValueTextPair', ['entity_value', 'original_text'])
 
 
 class BaseNumberRangeDetector(object):

--- a/ner_v2/tests/numeral/number_range/test_number_range_detection.py
+++ b/ner_v2/tests/numeral/number_range/test_number_range_detection.py
@@ -23,7 +23,6 @@ class NumberRangeDetectorTestMeta(type):
     def yaml_testsuite_generator(cls):
         for filepath in cls.yaml_test_files:
             test_data = yaml.load(io.open(filepath, "r", encoding="utf-8"))
-            print(test_data["tests"])
             for language in test_data["tests"]:
                 for i, testcase in enumerate(test_data["tests"][language]):
                     yield (

--- a/ner_v2/tests/numeral/number_range/test_number_range_detection.py
+++ b/ner_v2/tests/numeral/number_range/test_number_range_detection.py
@@ -23,6 +23,7 @@ class NumberRangeDetectorTestMeta(type):
     def yaml_testsuite_generator(cls):
         for filepath in cls.yaml_test_files:
             test_data = yaml.load(io.open(filepath, "r", encoding="utf-8"))
+            print(test_data["tests"])
             for language in test_data["tests"]:
                 for i, testcase in enumerate(test_data["tests"][language]):
                     yield (

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ six==1.11.0
 gunicorn==19.6.0
 pytz==2014.2
 nltk==3.4.5
-numpy==1.10.4
+numpy==1.16
 elasticsearch==5.5.0
 requests==2.20.0
 requests-aws4auth==0.9


### PR DESCRIPTION
This PR contains the following:

1. Numpy upgrade to 1.16 from 1.10.4 to fix the following error we get in python 3: ''numpy.ufunc has the wrong size, try recompiling. Expected 192, got 216''

2. re.compile fixes as python 3 does not support **ur** strings

3. Fixed escape sequences in regex