### PR TITLE
Update Elasticsearch mappings for entity indices

### DIFF
--- a/config.example
+++ b/config.example
@@ -34,8 +34,8 @@ ES_ALIAS=entity_data
 ES_INDEX_1=entity_data_v1
 ES_INDEX_2=
 ES_DOC_TYPE=data_dictionary
-ELASTICSEARCH_CRF_DATA_DOC_TYPE=training_dictionary
 ELASTICSEARCH_CRF_DATA_INDEX_NAME=entity_examples_data
+ELASTICSEARCH_CRF_DATA_DOC_TYPE=training_dictionary
 
 ES_BULK_MSG_SIZE=1000
 ES_SEARCH_SIZE=10000

--- a/datastore/datastore.py
+++ b/datastore/datastore.py
@@ -217,12 +217,15 @@ class DataStore(six.with_metaclass(Singleton, object)):
             for (index_name_key, alias_name) in delete_map:
                 if self._connection_settings.get(index_name_key):
                     index_name = self._connection_settings.get(index_name_key)
+                    if alias_name:
+                        elastic_search.create.delete_alias(connection=self._client_or_connection,
+                                                           index_list=[index_name],
+                                                           logger=ner_logger)
                     elastic_search.create.delete_index(connection=self._client_or_connection,
                                                        index_name=index_name,
                                                        logger=ner_logger,
                                                        err_if_does_not_exist=err_if_does_not_exist,
                                                        **kwargs)
-            # TODO: cleanup aliases ?
 
     # === Incompatible or deprecated/duplicate APIs
 

--- a/datastore/datastore.py
+++ b/datastore/datastore.py
@@ -208,10 +208,11 @@ class DataStore(six.with_metaclass(Singleton, object)):
             self._connect()
 
         if self._engine == ELASTICSEARCH:
-            for index_key in [ELASTICSEARCH_INDEX_1, ELASTICSEARCH_INDEX_2, ELASTICSEARCH_CRF_DATA_INDEX_NAME]:
-                if self._connection_settings.get(index_key):
+            for index_name_key in [ELASTICSEARCH_INDEX_1, ELASTICSEARCH_INDEX_2, ELASTICSEARCH_CRF_DATA_INDEX_NAME]:
+                if self._connection_settings.get(index_name_key):
+                    index_name = self._connection_settings.get(index_name_key)
                     elastic_search.create.delete_index(connection=self._client_or_connection,
-                                                       index_name=self._store_name,
+                                                       index_name=index_name,
                                                        logger=ner_logger,
                                                        err_if_does_not_exist=err_if_does_not_exist,
                                                        **kwargs)

--- a/datastore/datastore.py
+++ b/datastore/datastore.py
@@ -209,25 +209,15 @@ class DataStore(six.with_metaclass(Singleton, object)):
             self._connect()
 
         if self._engine == ELASTICSEARCH:
-            delete_map = [
-                (ELASTICSEARCH_INDEX_1, self._store_name),
-                (ELASTICSEARCH_INDEX_2, self._store_name),
-                (ELASTICSEARCH_CRF_DATA_INDEX_NAME, None),
-            ]
-            for (index_name_key, alias_name) in delete_map:
+            delete_map = [ELASTICSEARCH_INDEX_1, ELASTICSEARCH_INDEX_2, ELASTICSEARCH_CRF_DATA_INDEX_NAME]
+            for index_name_key in delete_map:
                 if self._connection_settings.get(index_name_key):
                     index_name = self._connection_settings.get(index_name_key)
-                    if alias_name:
-                        elastic_search.create.delete_alias(connection=self._client_or_connection,
-                                                           index_list=[index_name],
-                                                           alias_name=alias_name,
-                                                           logger=ner_logger)
                     elastic_search.create.delete_index(connection=self._client_or_connection,
                                                        index_name=index_name,
                                                        logger=ner_logger,
                                                        err_if_does_not_exist=err_if_does_not_exist,
                                                        **kwargs)
-
     # === Incompatible or deprecated/duplicate APIs
 
     # FIXME: repopulate does not consider language of the variants

--- a/datastore/datastore.py
+++ b/datastore/datastore.py
@@ -220,6 +220,7 @@ class DataStore(six.with_metaclass(Singleton, object)):
                     if alias_name:
                         elastic_search.create.delete_alias(connection=self._client_or_connection,
                                                            index_list=[index_name],
+                                                           alias_name=alias_name,
                                                            logger=ner_logger)
                     elastic_search.create.delete_index(connection=self._client_or_connection,
                                                        index_name=index_name,

--- a/datastore/datastore.py
+++ b/datastore/datastore.py
@@ -151,7 +151,6 @@ class DataStore(six.with_metaclass(Singleton, object)):
 
         if self._engine == ELASTICSEARCH:
             es_url = elastic_search.connect.get_es_url()
-            es_object = elastic_search.transfer.ESTransfer(source=es_url, destination=None)
             create_map = [  # TODO: use namedtuples
                 (True, ELASTICSEARCH_INDEX_1, ELASTICSEARCH_DOC_TYPE, self._store_name,
                  self._check_doc_type_for_elasticsearch, elastic_search.create.create_entity_index),
@@ -180,8 +179,10 @@ class DataStore(six.with_metaclass(Singleton, object)):
                     **kwargs
                 )
                 if alias_name:
-                    es_object.point_an_alias_to_index(es_url=es_url, alias_name=self._store_name,
-                                                      index_name=index_name)
+                    elastic_search.create.create_alias(connection=self._client_or_connection,
+                                                       index_list=[index_name],
+                                                       alias_name=alias_name,
+                                                       logger=ner_logger)
 
     def delete(self, err_if_does_not_exist=True, **kwargs):
         """
@@ -208,7 +209,12 @@ class DataStore(six.with_metaclass(Singleton, object)):
             self._connect()
 
         if self._engine == ELASTICSEARCH:
-            for index_name_key in [ELASTICSEARCH_INDEX_1, ELASTICSEARCH_INDEX_2, ELASTICSEARCH_CRF_DATA_INDEX_NAME]:
+            delete_map = [
+                (ELASTICSEARCH_INDEX_1, self._store_name),
+                (ELASTICSEARCH_INDEX_2, self._store_name),
+                (ELASTICSEARCH_CRF_DATA_INDEX_NAME, None),
+            ]
+            for (index_name_key, alias_name) in delete_map:
                 if self._connection_settings.get(index_name_key):
                     index_name = self._connection_settings.get(index_name_key)
                     elastic_search.create.delete_index(connection=self._client_or_connection,

--- a/datastore/elastic_search/create.py
+++ b/datastore/elastic_search/create.py
@@ -206,10 +206,10 @@ def create_crf_index(connection, index_name, doc_type, logger, **kwargs):
                     'type': 'text'
                 },
                 'sentence': {
-                    'enabled': 'false'
+                    'enabled': False
                 },
                 'entities': {
-                    'enabled': 'false'
+                    'enabled': False
                 },
                 'language_script': {
                     'type': 'text'

--- a/datastore/elastic_search/create.py
+++ b/datastore/elastic_search/create.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, Dict, Any
 
 from elasticsearch import Elasticsearch
+from elasticsearch.exceptions import NotFoundError
 
 from .utils import filter_kwargs
 
@@ -48,7 +49,11 @@ def delete_index(connection, index_name, logger, err_if_does_not_exist=True, **k
         else:
             return
 
-    delete_alias(connection=connection, index_list=[index_name], alias_name='_all', logger=logger)
+    try:
+        delete_alias(connection=connection, index_list=[index_name], alias_name='_all', logger=logger)
+    except NotFoundError:
+        logger.warning('No aliases found on on index %s', index_name)
+
     connection.indices.delete(index=index_name, **kwargs)
     logger.debug('%s: Delete Index %s: Operation successfully completed', log_prefix, index_name)
 
@@ -251,9 +256,9 @@ def create_alias(connection, index_list, alias_name, logger, **kwargs):
         **kwargs:
             https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
     """
-    logger.debug('Putting alias %s to indices: %s' % (alias_name, str(index_list)))
+    logger.debug('Putting alias %s to indices: %s', alias_name, str(index_list))
     connection.indices.put_alias(index=index_list, name=alias_name, **kwargs)
-    logger.debug('Alias %s now points to indices %s' % (alias_name, str(index_list)))
+    logger.debug('Alias %s now points to indices %s', alias_name, str(index_list))
 
 
 def delete_alias(connection, index_list, alias_name, logger, **kwargs):
@@ -269,6 +274,6 @@ def delete_alias(connection, index_list, alias_name, logger, **kwargs):
         **kwargs:
             https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
     """
-    logger.debug('Removing alias %s from indices: %s' % (alias_name, str(index_list)))
+    logger.debug('Removing alias %s from indices: %s', alias_name, str(index_list))
     connection.indices.delete_alias(index=index_list, name=alias_name, **kwargs)
-    logger.debug('Alias %s removed from indices %s' % (alias_name, str(index_list)))
+    logger.debug('Alias %s removed from indices %s', alias_name, str(index_list))

--- a/datastore/elastic_search/create.py
+++ b/datastore/elastic_search/create.py
@@ -1,10 +1,16 @@
+import logging
+from typing import List, Dict, Any
+
+from elasticsearch import Elasticsearch
+
 from .utils import filter_kwargs
 
 log_prefix = 'datastore.elastic_search.create'
 
 
 def exists(connection, index_name):
-    '''
+    # type: (Elasticsearch, str) -> bool
+    """
     Checks if index_name exists
 
     Args:
@@ -13,18 +19,20 @@ def exists(connection, index_name):
 
     Returns:
         boolean, True if index exists , False otherwise
-    '''
+    """
     return connection.indices.exists(index_name)
 
 
 def delete_index(connection, index_name, logger, err_if_does_not_exist=True, **kwargs):
-    '''
+    # type: (Elasticsearch, str, logging.Logger, bool, **Any) -> None
+    """
     Deletes the index named index_name
 
     Args:
         connection: Elasticsearch client object
         index_name: The name of the index
         logger: logging object to log at debug and exception level
+        err_if_does_not_exist: if to raise error if index does not exist already, defaults to True
         kwargs:
             body: The configuration for the index (settings and mappings)
             master_timeout: Specify timeout for connection to master
@@ -33,7 +41,7 @@ def delete_index(connection, index_name, logger, err_if_does_not_exist=True, **k
             wait_for_active_shards: Set the number of active shards to wait for before the operation returns.
 
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.delete
-    '''
+    """
     if not exists(connection, index_name):
         if err_if_does_not_exist:
             raise Exception('Failed to delete index {}. It does not exist!'.format(index_name))
@@ -45,7 +53,8 @@ def delete_index(connection, index_name, logger, err_if_does_not_exist=True, **k
 
 
 def _create_index(connection, index_name, doc_type, logger, mapping_body, err_if_exists=True, **kwargs):
-    '''
+    # type: (Elasticsearch, str, str, logging.Logger, Dict[str, Any], bool, **Any) -> None
+    """
     Creates an Elasticsearch index needed for similarity based searching
     Args:
         connection: Elasticsearch client object
@@ -53,6 +62,7 @@ def _create_index(connection, index_name, doc_type, logger, mapping_body, err_if
         doc_type:  The type of the documents that will be indexed
         logger: logging object to log at debug and exception level
         mapping_body: dict, mappings to put on the index
+        err_if_exists: if to raise error if the index already exists, defaults to True
         kwargs:
             master_timeout: Specify timeout for connection to master
             timeout: Explicit operation timeout
@@ -67,7 +77,7 @@ def _create_index(connection, index_name, doc_type, logger, mapping_body, err_if
                                 (missing or closed)
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.create
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.put_mapping
-    '''
+    """
     if exists(connection=connection, index_name=index_name):
         if err_if_exists:
             raise Exception('Failed to create index {}. it already exists. Please check and delete it using '
@@ -118,7 +128,8 @@ def _create_index(connection, index_name, doc_type, logger, mapping_body, err_if
 
 
 def create_entity_index(connection, index_name, doc_type, logger, **kwargs):
-    '''
+    # type: (Elasticsearch, str, str, logging.Logger, **Any) -> None
+    """
     Creates an mapping specific to entity storage in elasticsearch and makes a call to create_index
     to create the index with the given mapping body
     Args:
@@ -141,7 +152,7 @@ def create_entity_index(connection, index_name, doc_type, logger, **kwargs):
 
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.create
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.put_mapping
-    '''
+    """
     mapping_body = {
         doc_type: {
             'properties': {
@@ -180,7 +191,8 @@ def create_entity_index(connection, index_name, doc_type, logger, **kwargs):
 
 
 def create_crf_index(connection, index_name, doc_type, logger, **kwargs):
-    '''
+    # type: (Elasticsearch, str, str, logging.Logger, **Any) -> None
+    """
     This method is used to create an index with mapping suited for story training_data
     Args:
         connection: Elasticsearch client object
@@ -202,7 +214,7 @@ def create_crf_index(connection, index_name, doc_type, logger, **kwargs):
 
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.create
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.put_mapping
-    '''
+    """
     mapping_body = {
         doc_type: {
             'properties': {
@@ -226,17 +238,36 @@ def create_crf_index(connection, index_name, doc_type, logger, **kwargs):
 
 
 def create_alias(connection, index_list, alias_name, logger, **kwargs):
-    '''
+    # type: (Elasticsearch, List[str], str, logging.Logger, **Any) -> None
+    """
     This method is used to create alias for list of indices
     Args:
-        connection:
+        connection: Elasticsearch client object
         index_list (list): List of indices the alias has to point to
         alias_name (str): Name of the alias
         logger: logging object to log at debug and exception level
 
         **kwargs:
             https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
-    '''
-    logger.debug('Alias creation %s started %s' % alias_name)
+    """
+    logger.debug('Putting alias %s to indices: %s' % (alias_name, str(index_list)))
     connection.indices.put_alias(index=index_list, name=alias_name, **kwargs)
     logger.debug('Alias %s now points to indices %s' % (alias_name, str(index_list)))
+
+
+def delete_alias(connection, index_list, alias_name, logger, **kwargs):
+    # type: (Elasticsearch, List[str], str, logging.Logger, **Any) -> None
+    """
+    Delete alias `alias_name` from list of indices in `index_list`
+    Args:
+        connection: Elasticsearch client object
+        index_list (list): List of indices the alias has to point to
+        alias_name (str): Name of the alias
+        logger: logging object to log at debug and exception level
+
+        **kwargs:
+            https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
+    """
+    logger.debug('Removing alias %s from indices: %s' % (alias_name, str(index_list)))
+    connection.indices.delete_alias(index=index_list, name=alias_name, **kwargs)
+    logger.debug('Alias %s removed from indices %s' % (alias_name, str(index_list)))

--- a/datastore/elastic_search/create.py
+++ b/datastore/elastic_search/create.py
@@ -48,6 +48,7 @@ def delete_index(connection, index_name, logger, err_if_does_not_exist=True, **k
         else:
             return
 
+    delete_alias(connection=connection, index_list=[index_name], alias_name='_all', logger=logger)
     connection.indices.delete(index=index_name, **kwargs)
     logger.debug('%s: Delete Index %s: Operation successfully completed', log_prefix, index_name)
 

--- a/datastore/elastic_search/create.py
+++ b/datastore/elastic_search/create.py
@@ -4,7 +4,7 @@ log_prefix = 'datastore.elastic_search.create'
 
 
 def exists(connection, index_name):
-    """
+    '''
     Checks if index_name exists
 
     Args:
@@ -13,12 +13,12 @@ def exists(connection, index_name):
 
     Returns:
         boolean, True if index exists , False otherwise
-    """
+    '''
     return connection.indices.exists(index_name)
 
 
 def delete_index(connection, index_name, logger, err_if_does_not_exist=True, **kwargs):
-    """
+    '''
     Deletes the index named index_name
 
     Args:
@@ -33,7 +33,7 @@ def delete_index(connection, index_name, logger, err_if_does_not_exist=True, **k
             wait_for_active_shards: Set the number of active shards to wait for before the operation returns.
 
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.delete
-    """
+    '''
     if not exists(connection, index_name):
         if err_if_does_not_exist:
             raise Exception('Failed to delete index {}. It does not exist!'.format(index_name))
@@ -45,7 +45,7 @@ def delete_index(connection, index_name, logger, err_if_does_not_exist=True, **k
 
 
 def _create_index(connection, index_name, doc_type, logger, mapping_body, err_if_exists=True, **kwargs):
-    """
+    '''
     Creates an Elasticsearch index needed for similarity based searching
     Args:
         connection: Elasticsearch client object
@@ -67,7 +67,7 @@ def _create_index(connection, index_name, doc_type, logger, mapping_body, err_if
                                 (missing or closed)
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.create
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.put_mapping
-    """
+    '''
     if exists(connection=connection, index_name=index_name):
         if err_if_exists:
             raise Exception('Failed to create index {}. it already exists. Please check and delete it using '
@@ -118,7 +118,7 @@ def _create_index(connection, index_name, doc_type, logger, mapping_body, err_if
 
 
 def create_entity_index(connection, index_name, doc_type, logger, **kwargs):
-    """
+    '''
     Creates an mapping specific to entity storage in elasticsearch and makes a call to create_index
     to create the index with the given mapping body
     Args:
@@ -141,32 +141,36 @@ def create_entity_index(connection, index_name, doc_type, logger, **kwargs):
 
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.create
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.put_mapping
-    """
+    '''
     mapping_body = {
         doc_type: {
             'properties': {
                 'language_script': {
                     'type': 'text',
+                    'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}},
                 },
                 'value': {
                     'type': 'text',
+                    'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}},
                 },
                 'variants': {
                     'type': 'text',
+                    'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}},
                     'analyzer': 'my_analyzer',
-                    'norms': {
-                        'enabled': False  # Needed if we want to give longer variants higher scores
-                    },
+                    'norms': {'enabled': False},  # Needed if we want to give longer variants higher scores
                 },
                 # other removed/unused fields, kept only for backward compatibility
                 'dict_type': {
                     'type': 'text',
+                    'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}},
                 },
                 'entity_data': {
                     'type': 'text',
+                    'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}},
                 },
                 'source_language': {
                     'type': 'text',
+                    'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}},
                 }
             }
         }
@@ -176,7 +180,7 @@ def create_entity_index(connection, index_name, doc_type, logger, **kwargs):
 
 
 def create_crf_index(connection, index_name, doc_type, logger, **kwargs):
-    """
+    '''
     This method is used to create an index with mapping suited for story training_data
     Args:
         connection: Elasticsearch client object
@@ -198,7 +202,7 @@ def create_crf_index(connection, index_name, doc_type, logger, **kwargs):
 
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.create
         Refer https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IndicesClient.put_mapping
-    """
+    '''
     mapping_body = {
         doc_type: {
             'properties': {
@@ -222,7 +226,7 @@ def create_crf_index(connection, index_name, doc_type, logger, **kwargs):
 
 
 def create_alias(connection, index_list, alias_name, logger, **kwargs):
-    """
+    '''
     This method is used to create alias for list of indices
     Args:
         connection:
@@ -232,7 +236,7 @@ def create_alias(connection, index_list, alias_name, logger, **kwargs):
 
         **kwargs:
             https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
-    """
+    '''
     logger.debug('Alias creation %s started %s' % alias_name)
     connection.indices.put_alias(index=index_list, name=alias_name, **kwargs)
     logger.debug('Alias %s now points to indices %s' % (alias_name, str(index_list)))

--- a/datastore/elastic_search/create.py
+++ b/datastore/elastic_search/create.py
@@ -144,13 +144,29 @@ def create_entity_index(connection, index_name, doc_type, logger, **kwargs):
     """
     mapping_body = {
         doc_type: {
-            'properties': {
-                'variants': {
-                    'type': 'text',
-                    'analyzer': 'my_analyzer',
-                    'norms': {'enabled': False},  # Needed if we want to give longer variants higher scores
-                }
-            }
+            'language_script': {
+                'type': 'text',
+            },
+            'value': {
+                'type': 'text',
+            },
+            'variants': {
+                'type': 'text',
+                'analyzer': 'my_analyzer',
+                'norms': {
+                    'enabled': False  # Needed if we want to give longer variants higher scores
+                },
+            },
+            # other removed/unused fields, kept only for backward compatibility
+            'dict_type': {
+                'type': 'text',
+            },
+            'entity_data': {
+                'type': 'text',
+            },
+            'source_language': {
+                'type': 'text',
+            },
         }
     }
 
@@ -184,17 +200,17 @@ def create_crf_index(connection, index_name, doc_type, logger, **kwargs):
     mapping_body = {
         doc_type: {
             'properties': {
-                "entity_data": {
-                    "type": "text"
+                'entity_data': {
+                    'type': 'text'
                 },
-                "sentence": {
-                    "enabled": "false"
+                'sentence': {
+                    'enabled': 'false'
                 },
-                "entities": {
-                    "enabled": "false"
+                'entities': {
+                    'enabled': 'false'
                 },
-                "language_script": {
-                    "type": "text"
+                'language_script': {
+                    'type': 'text'
                 }
             }
         }

--- a/datastore/elastic_search/create.py
+++ b/datastore/elastic_search/create.py
@@ -144,29 +144,31 @@ def create_entity_index(connection, index_name, doc_type, logger, **kwargs):
     """
     mapping_body = {
         doc_type: {
-            'language_script': {
-                'type': 'text',
-            },
-            'value': {
-                'type': 'text',
-            },
-            'variants': {
-                'type': 'text',
-                'analyzer': 'my_analyzer',
-                'norms': {
-                    'enabled': False  # Needed if we want to give longer variants higher scores
+            'properties': {
+                'language_script': {
+                    'type': 'text',
                 },
-            },
-            # other removed/unused fields, kept only for backward compatibility
-            'dict_type': {
-                'type': 'text',
-            },
-            'entity_data': {
-                'type': 'text',
-            },
-            'source_language': {
-                'type': 'text',
-            },
+                'value': {
+                    'type': 'text',
+                },
+                'variants': {
+                    'type': 'text',
+                    'analyzer': 'my_analyzer',
+                    'norms': {
+                        'enabled': False  # Needed if we want to give longer variants higher scores
+                    },
+                },
+                # other removed/unused fields, kept only for backward compatibility
+                'dict_type': {
+                    'type': 'text',
+                },
+                'entity_data': {
+                    'type': 'text',
+                },
+                'source_language': {
+                    'type': 'text',
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Some mappings were found to be manually put outside of code which creates
a problem with new setups.

Fix a bunch of issues with `create` and `delete` index + aliases