### PR TITLE
Updated release drafter to enable Miscellaneous label as a normal category

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,5 +19,5 @@ categories:
     label: packages-updated
   - title: 👺 Miscellaneous 
     label: miscellaneous
-exclude-labels:
-  - miscellaneous
+# exclude-labels:
+#  - miscellaneous


### PR DESCRIPTION
## JIRA Ticket Number

JIRA TICKET: ADO-4873

## Description of change
Updated release drafter to enable Miscellaneous label as a normal category 
Removed miscellaneous from exclude-labels

## Checklist (OPTIONAL):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
