### PR TITLE
fix(v2/number): cast to int directly if no decimal point is found to avoid wrong values because of precision loss

### DIFF
--- a/ner_v2/detectors/numeral/number/standard_number_detector.py
+++ b/ner_v2/detectors/numeral/number/standard_number_detector.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import collections
 import os
+import decimal
 
 import pandas as pd
 from six.moves import zip
@@ -302,8 +303,12 @@ class BaseNumberDetector(object):
                 scale = 1
 
             if number:
-                number = float(number) * scale
-                number = int(number) if number.is_integer() else number
+                if '.' not in number:
+                    number = int(number) * scale
+                else:
+                    number = float(number) * scale
+                    # FIXME: this conversion from float -> int is lossy, consider using Decimal class
+                    number = int(number) if number.is_integer() else number
                 unit = None
                 if self.unit_type:
                     unit, original_text = self._get_unit_from_text(original_text, processed_text)

--- a/ner_v2/detectors/numeral/number/standard_number_detector.py
+++ b/ner_v2/detectors/numeral/number/standard_number_detector.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 import collections
 import os
-import decimal
 
 import pandas as pd
 from six.moves import zip

--- a/ner_v2/detectors/numeral/utils.py
+++ b/ner_v2/detectors/numeral/utils.py
@@ -26,6 +26,7 @@ def get_number_from_number_word(text, number_word_dict):
         [In]  >> _get_number_from_numerals('two hundred three four hundred three',  number_word_dict)
         [Out] >> (['103', '403'], ['one hundred three', 'four hundred three'])
     """
+    # FIXME: conversion from float -> int is lossy, consider using Decimal class
     detected_number_list = []
     detected_original_text_list = []
 

--- a/ner_v2/tests/numeral/number/en/number_ner_tests.yaml
+++ b/ner_v2/tests/numeral/number/en/number_ner_tests.yaml
@@ -176,3 +176,17 @@ tests:
         output_id: 3
         unit: rupees
         value: "50000"
+  - id: en_14
+    message: "here are some super large numbers 12345678901234567890 12345678 987654321012345678901 98765432101234567890123 "
+    unit_type: null
+    min_digit: 20
+    max_digit: 22
+    outputs:
+      - original_text: "12345678901234567890"
+        output_id: 1
+        unit: null
+        value: "12345678901234567890"
+      - original_text: "987654321012345678901"
+        output_id: 2
+        unit: null
+        value: "987654321012345678901"

--- a/ner_v2/tests/numeral/number/en/test_number_detection.py
+++ b/ner_v2/tests/numeral/number/en/test_number_detection.py
@@ -194,6 +194,9 @@ class NumberDetectorTestMeta(type):
             message = testcase["message"]
             unit_type = testcase.get("unit_type", None)
             number_detector_object = NumberDetector(entity_name="number", language=language, unit_type=unit_type)
+            number_detector_object.set_min_max_digits(
+                min_digit=testcase.get('min_digit', number_detector_object.min_digit),
+                max_digit=testcase.get('max_digit', number_detector_object.max_digit))
             number_dicts, spans = number_detector_object.detect_entity(message)
 
             expected_number_dicts, expected_spans = parse_expected_outputs(testcase["outputs"])


### PR DESCRIPTION
## JIRA Ticket Number

JIRA TICKET:  ML-2315

## Description of change
Cast to int directly if no decimal point is found to avoid wrong values because of precision loss.

## Checklist (OPTIONAL):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
