### PR TITLE
fix(search): search on .keyword if value search term contains whitespace

### DIFF
--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -8,13 +8,13 @@ import re
 import warnings
 
 from six import string_types
+from six.moves import range
+from six.moves import zip
 
 from datastore import constants
 from external_api.constants import SENTENCE, ENTITIES
 from language_utilities.constant import ENGLISH_LANG
 from lib.nlp.const import TOKENIZER
-from six.moves import range
-from six.moves import zip
 
 # Local imports
 
@@ -213,9 +213,14 @@ def get_entity_unique_values(connection, index_name, doc_type, entity_name, valu
 
     if value_search_term:
         data['query']['bool']['minimum_should_match'] = 1
+        _search_field = 'value'
+        _search_term = value_search_term.lower()
+        if len(_search_term.split()) > 1:
+            # terms with spaces in them do not support wild queries on analyzed fields
+            _search_field = 'value.keyword'
         data['query']['bool']['should'].append({
             "wildcard": {
-                "value": u"*{0}*".format(value_search_term.lower())
+                _search_field: u"*{0}*".format(_search_term)
             }
         })
 


### PR DESCRIPTION
## JIRA Ticket Number

JIRA TICKET: ML-2345

## Description of change
Wildcard queries do not work on analyzed fields if the search term has whitespace. So we switch to search on `.keyword` which is a non analyzed version

## Checklist (OPTIONAL):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
