### PR TITLE
Try compiling with `regex.V0` engine if `regex.V1` fails

### DIFF
--- a/lib/nlp/tokenizer.py
+++ b/lib/nlp/tokenizer.py
@@ -1,11 +1,22 @@
 from __future__ import absolute_import
-import re
-import nltk
-import regex
 
-# constants
-from lib.singleton import Singleton
+from chatbot_ner.config import ner_logger
+
+try:
+    import regex as re
+
+    _re_flags = re.UNICODE | re.V1 | re.WORD
+
+except ImportError:
+    ner_logger.warning('Error importing `regex` lib, falling back to stdlib re')
+    import re
+
+    _re_flags = re.UNICODE
+
+import nltk
 import six
+
+from lib.singleton import Singleton
 
 NLTK_TOKENIZER = 'WORD_TOKENIZER'
 PRELOADED_NLTK_TOKENIZER = 'PRELOADED_NLTK_TOKENIZER'
@@ -52,7 +63,8 @@ class Tokenizer(six.with_metaclass(Singleton, object)):
         Tokenizer that mimicks Elasticsearch/Lucene's standard tokenizer
         Uses word boundaries defined in Unicode Annex 29
         """
-        words_pattern = regex.compile(r'\w(?:\B\S)*', flags=regex.V1 | regex.WORD | regex.UNICODE)
+
+        words_pattern = re.compile(r'\w(?:\B\S)*', flags=_re_flags)
 
         def word_tokenize(text):
             return words_pattern.findall(text)

--- a/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
+++ b/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
@@ -3,8 +3,14 @@ from __future__ import absolute_import
 
 import re
 
+try:
+    import regex
+
+    _regex_available = True
+except ImportError:
+    _regex_available = False
+
 import phonenumbers
-import regex
 from six.moves import zip
 
 from language_utilities.constant import ENGLISH_LANG
@@ -35,6 +41,10 @@ class PhoneDetector(BaseDetector):
         super(PhoneDetector, self).__init__(language, locale)
         self.language = language
         self.locale = locale or 'en-IN'
+        if _regex_available:
+            # This will replace all types of dashes(em or en) by hyphen.
+            self.locale = regex.sub('\\p{Pd}', '-', self.locale)
+
         self.text = ''
         self.phone, self.original_phone_text = [], []
         self.country_code = self.get_country_code_from_locale()
@@ -55,8 +65,6 @@ class PhoneDetector(BaseDetector):
         This method sets self.country_code from given locale
         """
         regex_pattern = re.compile('[-_](.*$)', re.U)
-        self.locale = regex.sub("\\p{Pd}", "-",
-                                self.locale)  # This will replace all types of dashes(em or en) by hyphen.
         match = regex_pattern.findall(self.locale)
         if match:
             return match[0].upper()


### PR DESCRIPTION
## JIRA Ticket Number

JIRA TICKET: ML-2442

## Description of change
For RegexDetector, try compiling with `regex.V0` engine if `regex.V1` fails beforegiving up

## Checklist (OPTIONAL):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
