### PR TITLE
Drop Elasticsearch client instance if ping fails and raise exception

### DIFF
--- a/chatbot_ner/config.py
+++ b/chatbot_ner/config.py
@@ -44,15 +44,9 @@ ES_INDEX_1 = os.environ.get('ES_INDEX_1')
 ES_DOC_TYPE = os.environ.get('ES_DOC_TYPE', 'data_dictionary')
 ES_AUTH_NAME = os.environ.get('ES_AUTH_NAME')
 ES_AUTH_PASSWORD = os.environ.get('ES_AUTH_PASSWORD')
-ES_BULK_MSG_SIZE = os.environ.get('ES_BULK_MSG_SIZE', '10000')
-ES_SEARCH_SIZE = os.environ.get('ES_SEARCH_SIZE', '10000')
-
-try:
-    ES_BULK_MSG_SIZE = int(ES_BULK_MSG_SIZE)
-    ES_SEARCH_SIZE = int(ES_SEARCH_SIZE)
-except ValueError:
-    ES_BULK_MSG_SIZE = 1000
-    ES_SEARCH_SIZE = 1000
+ES_BULK_MSG_SIZE = int((os.environ.get('ES_BULK_MSG_SIZE') or '').strip() or '1000')
+ES_SEARCH_SIZE = int((os.environ.get('ES_SEARCH_SIZE') or '').strip() or '1000')
+ES_REQUEST_TIMEOUT = int((os.environ.get('ES_REQUEST_TIMEOUT') or '').strip() or '20')
 
 ELASTICSEARCH_CRF_DATA_INDEX_NAME = os.environ.get('ELASTICSEARCH_CRF_DATA_INDEX_NAME')
 ELASTICSEARCH_CRF_DATA_DOC_TYPE = os.environ.get('ELASTICSEARCH_CRF_DATA_DOC_TYPE')
@@ -91,7 +85,7 @@ CHATBOT_NER_DATASTORE = {
         'retry_on_timeout': False,
         'max_retries': 1,
         'timeout': 20,
-        'request_timeout': 20,
+        'request_timeout': ES_REQUEST_TIMEOUT,
 
         # Transfer Specific constants (ignore if only one elasticsearch is setup)
         # For detailed explanation datastore.elastic_search.transfer.py

--- a/chatbot_ner/urls.py
+++ b/chatbot_ner/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
     url(r'^v2/number_range_bulk/$', api_v2.number_range),
     url(r'^v2/phone_number_bulk/$', api_v2.phone_number),
 
-    # Dictionary Read Write
+    # Deprecated dictionary read write, use entities/data/v1/*
     url(r'^entities/get_entity_word_variants', external_api.get_entity_word_variants),
     url(r'^entities/update_dictionary', external_api.update_dictionary),
 
@@ -54,7 +54,7 @@ urlpatterns = [
     url(r'^entities/get_crf_training_data', external_api.get_crf_training_data),
     url(r'^entities/update_crf_training_data', external_api.update_crf_training_data),
 
-    #  Train Crf Model
+    # Deprecated train crf model
     url(r'^entities/train_crf_model', external_api.train_crf_model),
 
     url(r'^entities/languages/v1/(?P<entity_name>.+)$', external_api.entity_language_view),

--- a/external_api/api.py
+++ b/external_api/api.py
@@ -55,7 +55,7 @@ def get_entity_word_variants(request):
         ner_logger.exception('Error: %s' % error_message)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
 
-    except BaseException as e:
+    except Exception as e:
         response['error'] = str(e)
         ner_logger.exception('Error: %s' % e)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
@@ -92,7 +92,7 @@ def update_dictionary(request):
         ner_logger.exception('Error: %s' % error_message)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
 
-    except BaseException as e:
+    except Exception as e:
         response['error'] = str(e)
         ner_logger.exception('Error: %s' % e)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
@@ -125,7 +125,7 @@ def transfer_entities(request):
         ner_logger.exception('Error: %s' % error_message)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
 
-    except BaseException as e:
+    except Exception as e:
         response['error'] = str(e)
         ner_logger.exception('Error: %s' % e)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
@@ -166,7 +166,7 @@ def get_crf_training_data(request):
         ner_logger.exception('Error: %s' % error_message)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
 
-    except BaseException as e:
+    except Exception as e:
         response['error'] = str(e)
         ner_logger.exception('Error: %s' % e)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
@@ -193,8 +193,7 @@ def update_crf_training_data(request):
         external_api_data = json.loads(request.POST.get(EXTERNAL_API_DATA))
         sentences = external_api_data.get(SENTENCES)
         entity_name = external_api_data.get(ENTITY_NAME)
-        DataStore().update_entity_crf_data(entity_name=entity_name,
-                                           sentences=sentences)
+        DataStore().update_entity_crf_data(entity_name=entity_name, sentences=sentences)
         response['success'] = True
 
     except (DataStoreSettingsImproperlyConfiguredException,
@@ -204,7 +203,7 @@ def update_crf_training_data(request):
         ner_logger.exception('Error: %s' % error_message)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
 
-    except BaseException as e:
+    except Exception as e:
         response['error'] = str(e)
         ner_logger.exception('Error: %s' % e)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
@@ -257,7 +256,7 @@ def train_crf_model(request):
         ner_logger.exception('Error: %s' % error_message)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)
 
-    except BaseException as e:
+    except Exception as e:
         response['error'] = str(e)
         ner_logger.exception('Error: %s' % e)
         return HttpResponse(json.dumps(response), content_type='application/json', status=500)

--- a/ner_v2/detectors/textual/elastic_search.py
+++ b/ner_v2/detectors/textual/elastic_search.py
@@ -1,98 +1,66 @@
 from __future__ import absolute_import
 
 import json
-import six
 
-from itertools import chain
+import six
 from elasticsearch import Elasticsearch
 
-from lib.singleton import Singleton
 from chatbot_ner.config import ner_logger, CHATBOT_NER_DATASTORE
 from datastore import constants
-from datastore.exceptions import DataStoreSettingsImproperlyConfiguredException, DataStoreRequestException
+from datastore.exceptions import (EngineConnectionException, DataStoreSettingsImproperlyConfiguredException,
+                                  DataStoreRequestException)
 from language_utilities.constant import ENGLISH_LANG
+from lib.singleton import Singleton
+from ner_v2.detectors.textual.queries import _generate_multi_entity_es_query, _parse_multi_entity_es_results
 
-from ner_v2.detectors.textual.queries import _generate_multi_entity_es_query, \
-    _parse_multi_entity_es_results
 
-
+# NOTE: connection is a misleading term for this implementation, rather what we have are clients that manage
+# any real connections on their own
 class ElasticSearchDataStore(six.with_metaclass(Singleton, object)):
     """
-    Class responsible for holding connections and performing search in
-    ElasticSearch DB.
+    Instance responsible for holding connections and performing search in ElasticSearch DB.
     Used as a singleton in this module.
     """
 
     def __init__(self):
         self._engine_name = constants.ELASTICSEARCH
-        self._kwargs = {}
         self._conns = {}
         self._connection_settings = {}
-        self._connection = None
         self._index_name = None
-
-        self.query_data = []
-
-        # configure variables and connection
+        self._doc_type = None
         self._configure_store()
 
-        # define doc type
-        self.doc_type = self._connection_settings[
-            constants.ELASTICSEARCH_DOC_TYPE]
-
-    def _configure_store(self, **kwargs):
+    def _configure_store(self):
         """
-        Configure self variables and connection.
-        Also add default connection to registry with alias `default`
+        Configure self variables and connection settings.
         """
-        self._connection_settings = CHATBOT_NER_DATASTORE. \
-            get(self._engine_name)
-
+        self._connection_settings = CHATBOT_NER_DATASTORE.get(self._engine_name)
         if self._connection_settings is None:
             raise DataStoreSettingsImproperlyConfiguredException()
-
+        self._check_doc_type_for_elasticsearch()
         self._index_name = self._connection_settings[constants.ELASTICSEARCH_ALIAS]
-        self._connection = self.connect(**self._connection_settings)
+        self._doc_type = self._connection_settings[constants.ELASTICSEARCH_DOC_TYPE]
 
-        self._conns['default'] = self._connection
+    @property
+    def _default_connection(self):
+        return self._get_or_create_new_connection(alias='default', **self._connection_settings)
 
-    def add_new_connection(self, alias, conn):
-        """
-        Add new connection object, which can be  directly passed through as-is to
-        the connection registry.
-        """
-        self._conns[alias] = conn
-
-    def get_or_create_new_connection(self, alias="default", **kwargs):
+    def _get_or_create_new_connection(self, alias='default', **kwargs):
         """
         Retrieve a connection with given alias.
         Construct it if necessary (only when configuration was passed to us).
 
-        If some non-string alias has been passed through it assume a client instance
-        and will just return it as-is.
-
         Raises ``KeyError`` if no client (or its definition) is registered
         under the alias.
         """
-
-        if not isinstance(alias, six.string_types):
-            return alias
-
-        # connection already established
-        try:
-            return self._conns[alias]
-        except KeyError:
-            pass
-
-        # if not, try to create it a new connection
-        try:
+        if alias not in self._conns:
             conn = self.connect(**kwargs)
+            if not conn:
+                raise EngineConnectionException(engine=self._engine_name)
             self._conns[alias] = conn
-        except KeyError:
-            # no connection and no kwargs to set one up
-            raise KeyError("There is no connection with alias %r." % alias)
 
-    # check if this is necessary here
+        return self._conns[alias]
+
     def _check_doc_type_for_elasticsearch(self):
         """
         Checks if doc_type is present in connection settings, if not an exception is raised
@@ -101,30 +69,25 @@ class ElasticSearchDataStore(six.with_metaclass(Singleton, object)):
              DataStoreSettingsImproperlyConfiguredException if doc_type was not found in
              connection settings
         """
-        # TODO: This check should be during init or boot
         if constants.ELASTICSEARCH_DOC_TYPE not in self._connection_settings:
-            ner_logger.debug("No doc type is present")
+            ner_logger.debug("No doc type is present in chatbot_ner.config.CHATBOT_NER_DATASTORE")
             raise DataStoreSettingsImproperlyConfiguredException(
                 'Elasticsearch needs doc_type. Please configure ES_DOC_TYPE in your environment')
 
-    def generate_query_data(self, entities, texts, fuzziness_threshold=1,
-                            search_language_script=ENGLISH_LANG):
-
-        # check if text is string
+    def generate_query_data(self, entities, texts, fuzziness_threshold=1, search_language_script=ENGLISH_LANG):
         if isinstance(texts, str):
             texts = [texts]
 
-        index_header = json.dumps({'index': self._index_name, 'type': self.doc_type})
+        index_header = json.dumps({'index': self._index_name, 'type': self._doc_type})
+        query_parts = []
+        for text in texts:
+            query_parts.append(index_header)
+            text_query = _generate_multi_entity_es_query(entities=entities, text=text,
+                                                         fuzziness_threshold=fuzziness_threshold,
+                                                         language_script=search_language_script)
+            query_parts.append(json.dumps(text_query))
 
-        data = list(chain.from_iterable([[index_header,
-                                          json.dumps(_generate_multi_entity_es_query(
-                                              entities=entities,
-                                              text=each,
-                                              fuzziness_threshold=fuzziness_threshold,
-                                              language_script=search_language_script))]
-                                         for each in texts]))
-
-        return data
+        return query_parts
 
     def get_multi_entity_results(self, entities, texts, fuzziness_threshold=1,
                                  search_language_script=ENGLISH_LANG, **kwargs):
@@ -162,24 +125,19 @@ class ElasticSearchDataStore(six.with_metaclass(Singleton, object)):
                     ('TMOS', 'TMOS'), ('G.', 'G  Pulla Reddy Sweets')])}
             ]
         """
-
-        self._check_doc_type_for_elasticsearch()
         request_timeout = self._connection_settings.get('request_timeout', 20)
         index_name = self._index_name
 
         data = []
         for entity_list, text_list in zip(entities, texts):
-            data.extend(self.generate_query_data(entity_list, text_list, fuzziness_threshold,
-                                                 search_language_script))
+            data.extend(self.generate_query_data(entity_list, text_list, fuzziness_threshold, search_language_script))
 
         # add `\n` for each index_header and query data text entry
         query_data = '\n'.join(data)
-
-        kwargs = dict(body=query_data, doc_type=self.doc_type, index=index_name,
-                      request_timeout=request_timeout)
+        kwargs = dict(body=query_data, doc_type=self._doc_type, index=index_name, request_timeout=request_timeout)
         response = None
         try:
-            response = self._run_es_search(self._connection, **kwargs)
+            response = self._run_es_search(self._default_connection, **kwargs)
             results = _parse_multi_entity_es_results(response.get("responses"))
         except Exception as e:
             raise DataStoreRequestException(f'Error in datastore query on index: {index_name}', engine='elasticsearch',
@@ -205,6 +163,7 @@ class ElasticSearchDataStore(six.with_metaclass(Singleton, object)):
             Elasticsearch client connection object
 
         """
+        # TODO: This does not account for ES_SCHEME unless the connection is being made via `connection_url`
         connection = None
         if user and password:
             kwargs = dict(kwargs, http_auth=(user, password))
@@ -230,7 +189,6 @@ class ElasticSearchDataStore(six.with_metaclass(Singleton, object)):
         Returns:
             dictionary, search results from elasticsearch.ElasticSearch.msearch
         """
-
         return connection.msearch(**kwargs)
 
     @staticmethod
@@ -247,8 +205,7 @@ class ElasticSearchDataStore(six.with_metaclass(Singleton, object)):
         """
         if isinstance(fuzzy_setting, six.string_types):
             if constants.ELASTICSEARCH_VERSION_MAJOR > 6 \
-                    or (constants.ELASTICSEARCH_VERSION_MAJOR == 6
-                        and constants.ELASTICSEARCH_VERSION_MINOR >= 2):
+                    or (constants.ELASTICSEARCH_VERSION_MAJOR == 6 and constants.ELASTICSEARCH_VERSION_MINOR >= 2):
                 return fuzzy_setting
             return 'auto'
 

--- a/ner_v2/detectors/textual/elastic_search.py
+++ b/ner_v2/detectors/textual/elastic_search.py
@@ -30,6 +30,9 @@ class ElasticSearchDataStore(six.with_metaclass(Singleton, object)):
         self._doc_type = None
         self._configure_store()
 
+    def _clear_connections(self):
+        self._conns = {}
+
     def _configure_store(self):
         """
         Configure self variables and connection settings.
@@ -160,7 +163,7 @@ class ElasticSearchDataStore(six.with_metaclass(Singleton, object)):
             kwargs: any additional arguments will be passed on to the Transport class and, subsequently,
                     to the Connection instances.
         Returns:
-            Elasticsearch client connection object
+            Elasticsearch client connection object or None
 
         """
         # TODO: This does not account for ES_SCHEME unless the connection is being made via `connection_url`

--- a/ner_v2/detectors/textual/tests/test_elastic_search.py
+++ b/ner_v2/detectors/textual/tests/test_elastic_search.py
@@ -1,91 +1,157 @@
 from __future__ import absolute_import
 
-from django.test import TestCase
-from elasticsearch import Elasticsearch
 import json
 
+import mock
+from django.test import TestCase
+from elasticsearch import Elasticsearch
+
+from chatbot_ner.config import ES_SEARCH_SIZE, ES_ALIAS, ES_DOC_TYPE
+from datastore.exceptions import EngineConnectionException
 from ner_v2.detectors.textual.elastic_search import ElasticSearchDataStore
-from chatbot_ner.config import CHATBOT_NER_DATASTORE, ES_SEARCH_SIZE, ES_ALIAS, ES_DOC_TYPE
 
 
 class TestESDataStore(TestCase):
-    def test_elasticsearch_connection(self):
-        c = ElasticSearchDataStore()
+    # Note: All ES networks calls should be properly mocked so that tests can also run without an actual instance
+    # and also multiple success failure scenarios can be created
+    # TODO: Lot of these tests have overlaps in what they test, needs a cleanup
 
-        connection = c.get_or_create_new_connection('default')
+    def setUp(self):
+        self.elasticsearch_engine_settings = {
+            'es_scheme': 'http://',
+            'host': 'localhost',
+            'port': 9200,
+            'es_alias': 'test_alias',
+            'es_index_1': 'test_index',
+            'doc_type': 'test_doc_type',
+        }
 
+    @mock.patch('ner_v2.detectors.textual.elastic_search.Elasticsearch.ping')
+    def test_elasticsearch_default_connection(self, mocked_es_ping):
+        """Test default connection on `ElasticSearchDataStore`"""
+        mocked_es_ping.return_value = True
+        esdb = ElasticSearchDataStore()
+        self.assertIsInstance(esdb._default_connection, Elasticsearch)
+
+    @mock.patch('ner_v2.detectors.textual.elastic_search.Elasticsearch.ping')
+    def test_elasticsearch_reconnection(self, mocked_es_ping):
+        """Test that `ElasticSearchDataStore` recovers connection after a ping fails"""
+        esdb = ElasticSearchDataStore()
+        mocked_es_ping.return_value = False
+        with self.assertRaises(EngineConnectionException):
+            _ = esdb._default_connection
+
+        mocked_es_ping.return_value = True
+        self.assertIsInstance(esdb._default_connection, Elasticsearch)
+
+    @mock.patch('ner_v2.detectors.textual.elastic_search.Elasticsearch.ping')
+    def test_elasticsearch_connect_ping_success(self, mocked_es_ping):
+        """Test `ElasticSearchDataStore.connect` when ping succeeds"""
+        mocked_es_ping.return_value = True
+        connection = ElasticSearchDataStore.connect(**self.elasticsearch_engine_settings)
         self.assertIsInstance(connection, Elasticsearch)
 
-    # :TODO: configure parameters here
-    def test_elasticsearch_connect(self):
-        kwargs = CHATBOT_NER_DATASTORE.get('elasticsearch')
+    @mock.patch('ner_v2.detectors.textual.elastic_search.Elasticsearch.ping')
+    def test_elasticsearch_connect_ping_fail(self, mocked_es_ping):
+        """Test `ElasticSearchDataStore.connect` when ping fails"""
+        mocked_es_ping.return_value = False
+        with self.assertRaises(EngineConnectionException):
+            ElasticSearchDataStore.connect(**self.elasticsearch_engine_settings)
 
-        connection = ElasticSearchDataStore.connect(**kwargs)
-
+    @mock.patch('ner_v2.detectors.textual.elastic_search.Elasticsearch.ping')
+    def test_elasticsearch_get_connection_ping_success(self, mocked_es_ping):
+        """Test `ElasticSearchDataStore._get_or_create_new_connection` when ping succeeds"""
+        mocked_es_ping.return_value = True
+        esdb = ElasticSearchDataStore()
+        connection = esdb._get_or_create_new_connection(alias='test', **self.elasticsearch_engine_settings)
         self.assertIsInstance(connection, Elasticsearch)
 
-    def test_elasticsearch_get_connection(self):
-        c = ElasticSearchDataStore()
+    @mock.patch('ner_v2.detectors.textual.elastic_search.Elasticsearch.ping')
+    def test_elasticsearch_get_connection_ping_fail(self, mocked_es_ping):
+        """Test `ElasticSearchDataStore._get_or_create_new_connection` when ping fails"""
+        mocked_es_ping.return_value = False
+        with self.assertRaises(EngineConnectionException):
+            esdb = ElasticSearchDataStore()
+            esdb._get_or_create_new_connection(alias='test', **self.elasticsearch_engine_settings)
 
-        conn = c.get_or_create_new_connection()
-        self.assertIsInstance(conn, Elasticsearch)
+    @mock.patch('ner_v2.detectors.textual.elastic_search.Elasticsearch.ping')
+    def test_elasticsearch_add_connection(self, mocked_es_ping):
+        """Test `ElasticSearchDataStore._get_or_create_new_connection` with multiple connections"""
+        esdb = ElasticSearchDataStore()
+        self.assertEqual(len(esdb._conns), 0)
 
-    def test_elasticsearch_add_connection(self):
-        kwargs = CHATBOT_NER_DATASTORE.get('elasticsearch')
-        c = Elasticsearch(**kwargs)
+        mocked_es_ping.return_value = False
+        with self.assertRaises(EngineConnectionException):
+            esdb._get_or_create_new_connection()
+        self.assertEqual(len(esdb._conns), 0)
 
-        es = ElasticSearchDataStore()
-        es.add_new_connection('new', c)
+        mocked_es_ping.return_value = True
+        esdb._get_or_create_new_connection()
+        self.assertEqual(len(esdb._conns), 1)
 
-        conn = es.get_or_create_new_connection()
-        new_conn = es.get_or_create_new_connection('new')
+        esdb._get_or_create_new_connection('new', **self.elasticsearch_engine_settings)
+        self.assertEqual(len(esdb._conns), 2)
 
-        self.assertIsInstance(new_conn, Elasticsearch)
-        self.assertIsInstance(c, Elasticsearch)
-        self.assertIsInstance(conn, Elasticsearch)
+        esdb._get_or_create_new_connection()
+        esdb._get_or_create_new_connection('new', **self.elasticsearch_engine_settings)
+        self.assertEqual(len(esdb._conns), 2)
+
+        self.assertIn('default', esdb._conns)
+        self.assertIn('new', esdb._conns)
 
     def test_elasticsearch_get_dynamic_fuzziness_threshold(self):
         fuzzy = 1
-
         fuzzy_threshold = ElasticSearchDataStore._get_dynamic_fuzziness_threshold(fuzzy)
-
         self.assertEqual(fuzzy_threshold, fuzzy)
 
         fuzzy = '1'
-
         fuzzy_threshold = ElasticSearchDataStore._get_dynamic_fuzziness_threshold(fuzzy)
-
         self.assertEqual(fuzzy_threshold, 'auto')
 
-        # :TODO: Check if below is expected
         fuzzy = 'some_string'
-
         fuzzy_threshold = ElasticSearchDataStore._get_dynamic_fuzziness_threshold(fuzzy)
-
         self.assertEqual(fuzzy_threshold, 'auto')
 
     def test_add_query(self):
-        es = ElasticSearchDataStore()
+        esdb = ElasticSearchDataStore()
 
         entity_list_1 = ['city', 'restaurant']
         text_1 = "I want to go to mumbai"
 
-        query_data = es.generate_query_data(entities=entity_list_1, texts=text_1)
-
+        query_data = esdb.generate_query_data(entities=entity_list_1, texts=text_1)
         query_data = [json.loads(x) for x in query_data]
 
-        assert_data = [{'index': ES_ALIAS, 'type': ES_DOC_TYPE},
-                       {'_source': ['value', 'entity_data'],
-                        'query': {'bool': {'filter': [{'terms': {'entity_data': ['city',
-                                                                                 'restaurant']}},
-                                                      {'terms': {'language_script': ['en']}}],
-                                           'should': [{'match': {'variants': {'query': 'I want to go to mumbai',
-                                                                              'fuzziness': 1,
-                                                                              'prefix_length': 1}}}],
-                                           'minimum_should_match': 1}},
-                        'highlight': {'fields': {'variants': {'type': 'unified'}},
-                                      'order': 'score',
-                                      'number_of_fragments': 20},
-                        'size': ES_SEARCH_SIZE}]
+        assert_data = [
+            {'index': ES_ALIAS, 'type': ES_DOC_TYPE},
+            {
+                '_source': ['value', 'entity_data'],
+                'query': {
+                    'bool': {
+                        'filter': [
+                            {'terms': {'entity_data': ['city', 'restaurant']}},
+                            {'terms': {'language_script': ['en']}}
+                        ],
+                        'should': [{
+                            'match': {
+                                'variants': {
+                                    'query': 'I want to go to mumbai',
+                                    'fuzziness': 1,
+                                    'prefix_length': 1
+                                }
+                            }
+                        }],
+                        'minimum_should_match': 1
+                    }
+                },
+                'highlight': {
+                    'fields': {
+                        'variants': {'type': 'unified'}
+                    },
+                    'order': 'score',
+                    'number_of_fragments': 20
+                },
+                'size': ES_SEARCH_SIZE
+            }
+        ]
 
         self.assertEqual(query_data, assert_data)


### PR DESCRIPTION
## JIRA Ticket Number

JIRA TICKET: ML-2453

## Description of change
Since the `ElasticsearchDataStore` instance is a Singleton, if `connection.ping` fails the `Elasticsearch` client will be `None` till the interpreter gets to restart

## Checklist (OPTIONAL):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
