### PR TITLE
Bump newrelic to `5.24.0.153` for compatibility with Django 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.3.
 https://github.com/explosion/spacy-models/releases/download/es_core_news_sm-2.3.1/es_core_news_sm-2.3.1.tar.gz#egg=es_core_news_sm
 
 # Alerting and APMs
-newrelic==3.4.0.95
+newrelic==5.24.0.153
 elastic-apm==6.5.0
 sentry-sdk==1.3.0
 


### PR DESCRIPTION
Closes #446

## JIRA Ticket Number

JIRA TICKET: 

## Description of change
Fixes `'function' is not iterable` error with newrelic django exception handling

## Checklist (OPTIONAL):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
