### PR TITLE
fix: revert sorting on elasticsearch side for crf data and do it in memory

### DIFF
--- a/datastore/elastic_search/query.py
+++ b/datastore/elastic_search/query.py
@@ -580,12 +580,10 @@ def get_crf_data_for_entity_name(connection, index_name, doc_type, entity_name, 
             ]
             }
     """
-
+    # TODO: Enable sorting on ES side after verifying mappings are correctly setup.
+    #       Currently in datastore.elastic_search.create.create_crf_index we dont add keyword fields to
+    #       `language_script` and `sentence`. We need to add integration tests for these too
     data = {
-        "sort": [
-            {"language_script.keyword": {"order": "asc"}},
-            {"sentence.keyword": {"order": "asc"}},
-        ],
         "query": {
             "bool": {
                 "must": [
@@ -619,8 +617,10 @@ def get_crf_data_for_entity_name(connection, index_name, doc_type, entity_name, 
     # Parse hits
     results = search_results['hits']['hits']
 
-    language_mapped_results = collections.defaultdict(list)
+    # TODO: Remove and switch to sorting on ES side once mappings are set correctly
+    results.sort(key=lambda _doc: (_doc['_source']['language_script'], _doc['_source']['sentence']))
 
+    language_mapped_results = collections.defaultdict(list)
     for result in results:
         language_mapped_results[result['_source']['language_script']].append(
             {


### PR DESCRIPTION
## JIRA Ticket Number

JIRA TICKET: ML-2872

## Description of change
Temporary fix till we figure out the fastest and safest way to  migrate mappings

## Checklist (OPTIONAL):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
