### PR TITLE
(Enhancement): Get the national number and check its length is below 8 (including country code) and exclude them

### DIFF
--- a/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
+++ b/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 import re
-# import structlog
+import structlog
 
 try:
     import regex
@@ -17,7 +17,7 @@ from six.moves import zip
 from language_utilities.constant import ENGLISH_LANG, CHINESE_TRADITIONAL_LANG
 from ner_v2.detectors.base_detector import BaseDetector
 from ner_v2.detectors.numeral.number.number_detection import NumberDetector
-# ner_logger = structlog.getLogger('chatbot_ner')
+ner_logger = structlog.getLogger('chatbot_ner')
 
 
 class PhoneDetector(BaseDetector):
@@ -110,16 +110,13 @@ class PhoneDetector(BaseDetector):
 
                 # Get the national number and check its length is below 8 (including contry code) and \
                 # Exclude numbers that are too short to be a valid phone number (e.g., ticket numbers)
-                print(f"\n detect_entity - national_number_len = {national_number_len}")
-                print(f"\n detect_entity - self.text = {self.text}")
                 if national_number_len < 8:
                     self.original_phone_text.append(self.text)
                     continue
-            except Exception as e:
-                print(f"\n detect_entity got an error as {str(e)}")
+            except Exception:
                 # Not logging exception object as structlog.exception() will print entire traceback
-                # ner_logger.exception('Error in detect_entity function',
-                #                      phonenumbers_match_obj=match.__dict__, text=self.text)
+                ner_logger.exception('Error in detect_entity function',
+                                     phonenumbers_match_obj=match.__dict__, text=self.text)
 
             if match.number.country_code == phonenumbers.country_code_for_region(self.country_code):
                 self.phone.append(self.check_for_country_code(str(match.number.national_number)))

--- a/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
+++ b/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 import re
-import structlog
+# import structlog
 
 try:
     import regex
@@ -17,7 +17,7 @@ from six.moves import zip
 from language_utilities.constant import ENGLISH_LANG, CHINESE_TRADITIONAL_LANG
 from ner_v2.detectors.base_detector import BaseDetector
 from ner_v2.detectors.numeral.number.number_detection import NumberDetector
-ner_logger = structlog.getLogger('chatbot_ner')
+# ner_logger = structlog.getLogger('chatbot_ner')
 
 
 class PhoneDetector(BaseDetector):
@@ -110,13 +110,16 @@ class PhoneDetector(BaseDetector):
 
                 # Get the national number and check its length is below 8 (including contry code) and \
                 # Exclude numbers that are too short to be a valid phone number (e.g., ticket numbers)
+                print(f"\n detect_entity - national_number_len = {national_number_len}")
+                print(f"\n detect_entity - self.text = {self.text}")
                 if national_number_len < 8:
                     self.original_phone_text.append(self.text)
                     continue
-            except Exception:
+            except Exception as e:
+                print(f"\n detect_entity got an error as {str(e)}")
                 # Not logging exception object as structlog.exception() will print entire traceback
-                ner_logger.exception('Error in detect_entity function',
-                                     phonenumbers_match_obj=match.__dict__, text=self.text)
+                # ner_logger.exception('Error in detect_entity function',
+                #                      phonenumbers_match_obj=match.__dict__, text=self.text)
 
             if match.number.country_code == phonenumbers.country_code_for_region(self.country_code):
                 self.phone.append(self.check_for_country_code(str(match.number.national_number)))

--- a/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
+++ b/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
@@ -115,8 +115,7 @@ class PhoneDetector(BaseDetector):
                     continue
             except Exception:
                 # Not logging exception object as structlog.exception() will print entire traceback
-                ner_logger.exception('Error in detect_entity function',
-                                     phonenumbers_match_obj=match.__dict__, text=self.text)
+                ner_logger.exception('Error in detect_entity function', text=self.text)
 
             if match.number.country_code == phonenumbers.country_code_for_region(self.country_code):
                 self.phone.append(self.check_for_country_code(str(match.number.national_number)))

--- a/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
+++ b/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
@@ -101,7 +101,19 @@ class PhoneDetector(BaseDetector):
         """
         self.text = " " + text.lower().strip() + " "
         self.phone, self.original_phone_text = [], []
+
         for match in phonenumbers.PhoneNumberMatcher(self.text, self.country_code, leniency=0):
+            try:
+                national_number_len = len(str(match.number.national_number))
+
+                # Get the national number and check its length is below 8 (including contry code) and \
+                # Exclude numbers that are too short to be a valid phone number (e.g., ticket numbers)
+                if national_number_len < 8:
+                    self.original_phone_text.append(self.text)
+                    continue
+            except Exception:
+                pass
+
             if match.number.country_code == phonenumbers.country_code_for_region(self.country_code):
                 self.phone.append(self.check_for_country_code(str(match.number.national_number)))
                 self.original_phone_text.append(self.text[match.start:match.end])
@@ -111,6 +123,7 @@ class PhoneDetector(BaseDetector):
                                    "value": str(match.number.national_number)})
                 self.original_phone_text.append(self.text[match.start:match.end])
         self.phone, self.original_phone_text = self.check_for_alphas()
+
         return self.phone, self.original_phone_text
 
     def check_for_alphas(self):

--- a/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
+++ b/ner_v2/detectors/pattern/phone_number/phone_number_detection.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import re
+import structlog
 
 try:
     import regex
@@ -16,6 +17,7 @@ from six.moves import zip
 from language_utilities.constant import ENGLISH_LANG, CHINESE_TRADITIONAL_LANG
 from ner_v2.detectors.base_detector import BaseDetector
 from ner_v2.detectors.numeral.number.number_detection import NumberDetector
+ner_logger = structlog.getLogger('chatbot_ner')
 
 
 class PhoneDetector(BaseDetector):
@@ -112,7 +114,9 @@ class PhoneDetector(BaseDetector):
                     self.original_phone_text.append(self.text)
                     continue
             except Exception:
-                pass
+                # Not logging exception object as structlog.exception() will print entire traceback
+                ner_logger.exception('Error in detect_entity function',
+                                     phonenumbers_match_obj=match.__dict__, text=self.text)
 
             if match.number.country_code == phonenumbers.country_code_for_region(self.country_code):
                 self.phone.append(self.check_for_country_code(str(match.number.national_number)))


### PR DESCRIPTION
## JIRA Ticket Number AN-4218

JIRA TICKET: [https://hello-haptik.atlassian.net/browse/AN-4218](https://hello-haptik.atlassian.net/browse/AN-4218)

## Description of change
- Ignore numbers below 8 digits
- Tested it with below snippet.
- Here, if country code is default +91, so we can't put a check as `If country_code is None`.
- 

```
import re
import phonenumbers

regex_pattern = re.compile("[-_](.*$)", re.U)

locale = "en-IN"

match = regex_pattern.findall(locale)
country_code = match[0].upper()


def test(text):
    text = " " + text.lower().strip() + " "

    for match in phonenumbers.PhoneNumberMatcher(text, country_code, leniency=0):
        try:
            # Get the national number and check its length
            national_number_len = len(str(match.number.national_number))
            # Exclude numbers that are too short to be a valid phone number (e.g., ticket numbers)
            if national_number_len < 8:
                print(f"\n Skip masking for text = {text}")
            else:
                print(f"\n Apply masking for text = {text}")
        except Exception as e:
            print(str(e))


text = "call me on +1 (408) 912-6172"
test(text)

text = "call me on  9988776655"
test(text)

text = "call me on +1 1234567"
test(text)

text = "call me on 1234567"
test(text)

text = "call me on +91 12345"
test(text)


print("\nScript completed.")

```

With output as:

![Screenshot 2024-10-04 at 9 09 47 PM](https://github.com/user-attachments/assets/33356638-4299-4454-9be7-1602801976a7)
